### PR TITLE
metamath: a variety of theorems

### DIFF
--- a/_thm/Q1052678.md
+++ b/_thm/Q1052678.md
@@ -5,4 +5,11 @@ wikidata: Q1052678
 msc_classification: "54"
 wikipedia_links:
   - "[[Baire category theorem]]"
+metamath:
+  - status: formalized
+    library: L
+    url: "https://us.metamath.org/mpeuni/bcth.html"
+    identifiers: [bcth]
+    authors: [NM, Mario Carneiro]
+    date: 2007-10-28
 ---

--- a/_thm/Q1057919.md
+++ b/_thm/Q1057919.md
@@ -5,4 +5,11 @@ wikidata: Q1057919
 msc_classification: "20"
 wikipedia_links:
   - "[[Sylow theorems]]"
+metamath:
+  - status: formalized
+    library: L
+    url: "https://us.metamath.org/mpeuni/sylow1.html"
+    identifiers: [sylow1, sylow2, sylow3]
+    authors: [Mario Carneiro]
+    date: 2015-01-19
 ---

--- a/_thm/Q1082910.md
+++ b/_thm/Q1082910.md
@@ -5,4 +5,12 @@ wikidata: Q1082910
 msc_classification: "11"
 wikipedia_links:
   - "[[Integer partition#Odd parts and distinct parts|Euler's partition theorem]]"
+metamath:
+  - status: formalized
+    library: X
+    url: "https://us.metamath.org/mpeuni/eulerpart.html"
+    identifiers: [eulerpart]
+    authors: [Thierry Arnoux]
+    date: 2018-08-14
+    comment: "External library since it is part of a userbox"
 ---

--- a/_thm/Q1137206.md
+++ b/_thm/Q1137206.md
@@ -5,4 +5,11 @@ wikidata: Q1137206
 msc_classification: "26"
 wikipedia_links:
   - "[[Taylor's theorem]]"
+metamath:
+  - status: formalized
+    library: L
+    url: "https://us.metamath.org/mpeuni/taylth.html"
+    identifiers: [taylth]
+    authors: [Mario Carneiro]
+    date: 2017-01-01
 ---

--- a/_thm/Q11518.md
+++ b/_thm/Q11518.md
@@ -5,4 +5,11 @@ wikidata: Q11518
 msc_classification: "51"
 wikipedia_links:
   - "[[Pythagorean theorem]]"
+metamath:
+  - status: formalized
+    library: L
+    url: "https://us.metamath.org/mpeuni/pythag.html"
+    identifiers: [pythag]
+    authors: [David A. Wheeler]
+    date: 2015-06-13
 ---

--- a/_thm/Q1227703.md
+++ b/_thm/Q1227703.md
@@ -5,4 +5,12 @@ wikidata: Q1227703
 msc_classification: "11"
 wikipedia_links:
   - "[[Dirichlet's approximation theorem]]"
+metamath:
+  - status: formalized
+    library: X
+    url: "https://us.metamath.org/mpeuni/irrapx1.html"
+    identifiers: [irrapx1]
+    authors: [Stefan O'Rear]
+    date: 2014-09-14
+    comment: "External library since it is part of a userbox"
 ---

--- a/_thm/Q1472120.md
+++ b/_thm/Q1472120.md
@@ -5,4 +5,12 @@ wikidata: Q1472120
 msc_classification: "46"
 wikipedia_links:
   - "[[Hellinger&ndash;Toeplitz theorem]]"
+metamath:
+  - status: formalized
+    library: X
+    url: "https://us.metamath.org/mpeuni/htth.html"
+    identifiers: [htth]
+    authors: [NM]
+    date: 2008-01-11
+    comment: "Counts as external due to the deprecation of Part 18"
 ---

--- a/_thm/Q1506253.md
+++ b/_thm/Q1506253.md
@@ -5,4 +5,11 @@ wikidata: Q1506253
 msc_classification: "11"
 wikipedia_links:
   - "[[Euclid's theorem]]"
+metamath:
+  - status: formalized
+    library: L
+    url: "https://us.metamath.org/mpeuni/prminf.html"
+    identifiers: [prminf]
+    authors: [Paul Chapman]
+    date: 2012-11-28
 ---

--- a/_thm/Q179208.md
+++ b/_thm/Q179208.md
@@ -5,4 +5,11 @@ wikidata: Q179208
 msc_classification: "20"
 wikipedia_links:
   - "[[Cayley's theorem]]"
+metamath:
+  - status: formalized
+    library: L
+    url: "https://us.metamath.org/mpeuni/cayley.html"
+    identifiers: [cayley, cayleyth]
+    authors: [Paul Chapman, Mario Carneiro]
+    date: 2008-03-03
 ---

--- a/_thm/Q18206266.md
+++ b/_thm/Q18206266.md
@@ -5,4 +5,11 @@ wikidata: Q18206266
 msc_classification: "11"
 wikipedia_links:
   - "[[Euclid–Euler theorem]]"
+metamath:
+  - status: formalized
+    library: L
+    url: "https://us.metamath.org/mpeuni/perfect.html"
+    identifiers: [perfect]
+    authors: [Mario Carneiro]
+    date: 2016-05-17
 ---

--- a/_thm/Q188295.md
+++ b/_thm/Q188295.md
@@ -5,4 +5,11 @@ wikidata: Q188295
 msc_classification: "11"
 wikipedia_links:
   - "[[Fermat's little theorem]]"
+metamath:
+  - status: formalized
+    library: L
+    url: "https://us.metamath.org/mpeuni/fermltl.html"
+    identifiers: [fermltl]
+    authors: [Mario Carneiro, AV]
+    date: 2014-02-28
 ---

--- a/_thm/Q190556.md
+++ b/_thm/Q190556.md
@@ -5,4 +5,11 @@ wikidata: Q190556
 msc_classification: "30"
 wikipedia_links:
   - "[[De Moivre's formula|De Moivre's theorem]]"
+metamath:
+  - status: formalized
+    library: L
+    url: "https://us.metamath.org/mpeuni/demoivre.html"
+    identifiers: [demoivre]
+    authors: [NM]
+    date: 2007-07-24
 ---

--- a/_thm/Q192760.md
+++ b/_thm/Q192760.md
@@ -5,4 +5,11 @@ wikidata: Q192760
 msc_classification: "30"
 wikipedia_links:
   - "[[Fundamental theorem of algebra]]"
+metamath:
+  - status: formalized
+    library: L
+    url: "https://us.metamath.org/mpeuni/fta.html"
+    identifiers: [fta]
+    authors: [Mario Carneiro]
+    date: 2014-09-15
 ---

--- a/_thm/Q193878.md
+++ b/_thm/Q193878.md
@@ -6,4 +6,11 @@ msc_classification: "11"
 wikipedia_links:
   - "[[Chinese remainder theorem]]"
   - "[[Linear congruence theorem]]"
+metamath:
+  - status: formalized
+    library: L
+    url: "https://us.metamath.org/mpeuni/crth.html"
+    identifiers: [crth]
+    authors: [Mario Carneiro]
+    date: 2014-02-24
 ---

--- a/_thm/Q193910.md
+++ b/_thm/Q193910.md
@@ -5,4 +5,11 @@ wikidata: Q193910
 msc_classification: "11"
 wikipedia_links:
   - "[[Euler's theorem]]"
+metamath:
+  - status: formalized
+    library: L
+    url: "https://us.metamath.org/mpeuni/eulerth.html"
+    identifiers: [eulerth]
+    authors: [Mario Carneiro]
+    date: 2014-02-28
 ---

--- a/_thm/Q22952648.md
+++ b/_thm/Q22952648.md
@@ -5,4 +5,11 @@ wikidata: Q22952648
 msc_classification: "03"
 wikipedia_links:
   - "[[Cardinality of the continuum#Uncountability|Uncountability of the continuum]]"
+metamath:
+  - status: formalized
+    library: L
+    url: "https://us.metamath.org/mpeuni/ruc.html"
+    identifiers: [ruc]
+    authors: [NM]
+    date: 2004-10-13
 ---

--- a/_thm/Q26708.md
+++ b/_thm/Q26708.md
@@ -5,4 +5,11 @@ wikidata: Q26708
 msc_classification: "05"
 wikipedia_links:
   - "[[Binomial theorem]]"
+metamath:
+  - status: formalized
+    library: L
+    url: "https://us.metamath.org/mpeuni/binom.html"
+    identifiers: [binom]
+    authors: [NM, Mario Carneiro]
+    date: 2005-12-07
 ---

--- a/_thm/Q276082.md
+++ b/_thm/Q276082.md
@@ -5,4 +5,11 @@ wikidata: Q276082
 msc_classification: "11"
 wikipedia_links:
   - "[[Wilson's theorem]]"
+metamath:
+  - status: formalized
+    library: L
+    url: "https://us.metamath.org/mpeuni/wilth.html"
+    identifiers: [wilth]
+    authors: [Mario Carneiro, Fan Zheng]
+    date: 2015-01-24
 ---

--- a/_thm/Q2919401.md
+++ b/_thm/Q2919401.md
@@ -5,4 +5,11 @@ wikidata: Q2919401
 msc_classification: "11"
 wikipedia_links:
   - "[[Ostrowski's theorem]]"
+metamath:
+  - status: formalized
+    library: L
+    url: "https://us.metamath.org/mpeuni/ostth.html"
+    identifiers: [ostth]
+    authors: [Mario Carneiro]
+    date: 2014-09-10
 ---

--- a/_thm/Q318767.md
+++ b/_thm/Q318767.md
@@ -5,4 +5,11 @@ wikidata: Q318767
 msc_classification: "26"
 wikipedia_links:
   - "[[Abel's theorem]]"
+metamath:
+  - status: formalized
+    library: L
+    url: "https://us.metamath.org/mpeuni/abelth.html"
+    identifiers: [abelth]
+    authors: [Mario Carneiro]
+    date: 2015-04-02
 ---

--- a/_thm/Q3527205.md
+++ b/_thm/Q3527205.md
@@ -5,4 +5,11 @@ wikidata: Q3527205
 msc_classification: "15"
 wikipedia_links:
   - "[[Dimension theorem for vector spaces]]"
+metamath:
+  - status: formalized
+    library: L
+    url: "https://us.metamath.org/mpeuni/lvecdim.html"
+    identifiers: [lvecdim]
+    authors: [David Moews]
+    date: 2017-05-01
 ---

--- a/_thm/Q386292.md
+++ b/_thm/Q386292.md
@@ -5,4 +5,11 @@ wikidata: Q386292
 msc_classification: "11"
 wikipedia_links:
   - "[[Prime number theorem]]"
+metamath:
+  - status: formalized
+    library: L
+    url: "https://us.metamath.org/mpeuni/pnt.html"
+    identifiers: [pnt]
+    authors: [Mario Carneiro]
+    date: 2016-06-01
 ---

--- a/_thm/Q459547.md
+++ b/_thm/Q459547.md
@@ -5,4 +5,11 @@ wikidata: Q459547
 msc_classification: "51"
 wikipedia_links:
   - "[[Ptolemy's theorem]]"
+metamath:
+  - status: formalized
+    library: L
+    url: "https://us.metamath.org/mpeuni/ptolemy.html"
+    identifiers: [ptolemy]
+    authors: [David A. Wheeler]
+    date: 2015-05-31
 ---

--- a/_thm/Q472883.md
+++ b/_thm/Q472883.md
@@ -5,4 +5,11 @@ wikidata: Q472883
 msc_classification: "11"
 wikipedia_links:
   - "[[Quadratic reciprocity theorem]]"
+metamath:
+  - status: formalized
+    library: L
+    url: "https://us.metamath.org/mpeuni/lgsquad.html"
+    identifiers: [lgsquad]
+    authors: [Mario Carneiro]
+    date: 2015-06-19
 ---

--- a/_thm/Q474881.md
+++ b/_thm/Q474881.md
@@ -5,4 +5,11 @@ wikidata: Q474881
 msc_classification: "03"
 wikipedia_links:
   - "[[Cantor's theorem]]"
+metamath:
+  - status: formalized
+    library: L
+    url: "https://us.metamath.org/mpeuni/canth.html"
+    identifiers: [canth]
+    authors: [NM, Mario Carneiro]
+    date: 1994-08-07
 ---

--- a/_thm/Q536640.md
+++ b/_thm/Q536640.md
@@ -5,4 +5,11 @@ wikidata: Q536640
 msc_classification: "05"
 wikipedia_links:
   - "[[Hall's marriage theorem]]"
+metamath:
+  - status: formalized
+    library: L
+    url: "https://us.metamath.org/mpeuni/marypha1.html"
+    identifiers: [marypha1, marypha2]
+    authors: [Stefan O'Rear]
+    date: 2015-02-20
 ---

--- a/_thm/Q550402.md
+++ b/_thm/Q550402.md
@@ -5,4 +5,11 @@ wikidata: Q550402
 msc_classification: "11"
 wikipedia_links:
   - "[[Dirichlet's theorem on arithmetic progressions]]"
+metamath:
+  - status: formalized
+    library: L
+    url: "https://us.metamath.org/mpeuni/dirith.html"
+    identifiers: [dirith]
+    authors: [Mario Carneiro]
+    date: 2016-05-12
 ---

--- a/_thm/Q5504427.md
+++ b/_thm/Q5504427.md
@@ -5,4 +5,11 @@ wikidata: Q5504427
 msc_classification: "05"
 wikipedia_links:
   - "[[Friendship theorem]]"
+metamath:
+  - status: formalized
+    library: L
+    url: "https://us.metamath.org/mpeuni/friendship.html"
+    identifiers: [friendship]
+    authors: [Alexander van der Vakens]
+    date: 2018-10-09
 ---

--- a/_thm/Q632546.md
+++ b/_thm/Q632546.md
@@ -5,4 +5,11 @@ wikidata: Q632546
 msc_classification: "11"
 wikipedia_links:
   - "[[Bertrand's postulate]]"
+metamath:
+  - status: formalized
+    library: L
+    url: "https://us.metamath.org/mpeuni/bpos.html"
+    identifiers: [bpos]
+    authors: [Mario Carneiro]
+    date: 2014-03-14
 ---

--- a/_thm/Q656772.md
+++ b/_thm/Q656772.md
@@ -5,4 +5,11 @@ wikidata: Q656772
 msc_classification: "15"
 wikipedia_links:
   - "[[Cayley–Hamilton theorem]]"
+metamath:
+  - status: formalized
+    library: L
+    url: "https://us.metamath.org/mpeuni/cayleyhamilton.html"
+    identifiers: [cayleyhamilton]
+    authors: [Alexander van der Vekens]
+    date: 2019-11-25
 ---

--- a/_thm/Q670235.md
+++ b/_thm/Q670235.md
@@ -5,4 +5,11 @@ wikidata: Q670235
 msc_classification: "11"
 wikipedia_links:
   - "[[Fundamental theorem of arithmetic]]"
+metamath:
+  - status: formalized
+    library: L
+    url: "https://us.metamath.org/mpeuni/1arith2.html"
+    identifiers: [1arith2, 1arith]
+    authors: [Paul Chapman]
+    date: 2012-11-17
 ---

--- a/_thm/Q756946.md
+++ b/_thm/Q756946.md
@@ -5,4 +5,11 @@ wikidata: Q756946
 msc_classification: "11"
 wikipedia_links:
   - "[[Lagrange's four-square theorem]]"
+metamath:
+  - status: formalized
+    library: L
+    url: "https://us.metamath.org/mpeuni/4sq.html"
+    identifiers: [4sq]
+    authors: [Mario Carneiro]
+    date: 2014-07-16
 ---

--- a/_thm/Q764287.md
+++ b/_thm/Q764287.md
@@ -5,4 +5,11 @@ wikidata: Q764287
 msc_classification: "05"
 wikipedia_links:
   - "[[Van der Waerden's theorem]]"
+metamath:
+  - status: formalized
+    library: L
+    url: "https://us.metamath.org/mpeuni/vdw.html"
+    identifiers: [vdw, vdwnn]
+    authors: [Mario Carneiro]
+    date: 2014-09-13
 ---

--- a/_thm/Q810431.md
+++ b/_thm/Q810431.md
@@ -1,4 +1,4 @@
-    ---
+---
 # Basel problem
 
 wikidata: Q810431

--- a/_thm/Q810431.md
+++ b/_thm/Q810431.md
@@ -1,8 +1,15 @@
----
+    ---
 # Basel problem
 
 wikidata: Q810431
 msc_classification: "26"
 wikipedia_links:
   - "[[Basel problem]]"
+metamath:
+  - status: formalized
+    library: L
+    url: "https://us.metamath.org/mpeuni/basel.html"
+    identifiers: [basel]
+    authors: [Mario Carneiro]
+    date: 2014-07-30
 ---

--- a/_thm/Q914517.md
+++ b/_thm/Q914517.md
@@ -5,4 +5,11 @@ wikidata: Q914517
 msc_classification: "11"
 wikipedia_links:
   - "[[Fermat's theorem on sums of two squares]]"
+metamath:
+  - status: formalized
+    library: L
+    url: "https://us.metamath.org/mpeuni/2sq.html"
+    identifiers: [2sq]
+    authors: [Mario Carneiro]
+    date: 2015-06-20
 ---

--- a/_thm/Q918099.md
+++ b/_thm/Q918099.md
@@ -5,4 +5,11 @@ wikidata: Q918099
 msc_classification: "05"
 wikipedia_links:
   - "[[Ramsey's theorem]]"
+metamath:
+  - status: formalized
+    library: L
+    url: "https://us.metamath.org/mpeuni/ramsey.html"
+    identifiers: [ramsey, ramcl]
+    authors: [Mario Carneiro]
+    date: 2015-04-23
 ---

--- a/_thm/Q976607.md
+++ b/_thm/Q976607.md
@@ -5,4 +5,12 @@ wikidata: Q976607
 msc_classification: "52"
 wikipedia_links:
   - "[[Erdős–Szekeres theorem]]"
+metamath:
+  - status: formalized
+    library: X
+    url: "https://us.metamath.org/mpeuni/erdsze.html"
+    identifiers: [erdsze]
+    authors: [Mario Carneiro]
+    date: 2015-01-22
+    comment: "External library since it is part of a userbox"
 ---


### PR DESCRIPTION
37 theorems from metamath set.mm. If this does not match any format or (future) PR specs let me know - just felt like it was too much work to not contribute it.

I treat mathboxes from users that are in some sense not part of the "official" set.mm library as external libraries even though they're in the same file, which seems like a good convention since they may depend on the non-mathbox part, but not the other way around.