### PR TITLE
chore: fix entry for Stone-Weierstrass; remove identifiers

### DIFF
--- a/_thm/Q208416.md
+++ b/_thm/Q208416.md
@@ -10,7 +10,6 @@ lean:
   - status: formalized
     library: X
     url: "https://github.com/flypitch/flypitch"
-    identifiers: [independence_of_CH]
     authors: [Floris van Doorn, Jesse Michael Han]
     date: 2019-09-17
 ---

--- a/_thm/Q939927.md
+++ b/_thm/Q939927.md
@@ -9,8 +9,7 @@ wikipedia_links:
 lean:
   - status: formalized
     library: L
-    url: "https://github.com/leanprover-community/mathlib4/blob/master/Mathlib/Topology/ContinuousFunction/StoneWeierstrass.lean"
-    identifiers: [stone_weierstrass]
+    url: "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Topology/ContinuousMap/StoneWeierstrass.html#ContinuousMap.subalgebra_topologicalClosure_eq_top_of_separatesPoints"
     authors: [Scott Morrison, Heather Macbeth]
     date: 2021-05-01
 ---


### PR DESCRIPTION
- the entry for the Stone-Weierstrass theorem was outdated; update the URL
- remove the 'identifiers' field from this and the continuum hypothesis entry
(which are the only occurrences of these fields): in https://github.com/1000-plus/1000-plus.github.io/pull/7, the identifiers
fields will be removed from the README.