### PR TITLE
fix/chore: update documentation of the file format

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,21 +16,21 @@ We welcome contributions! Please open a PR with additions or corrections!
 The files should start and end with a row containing exactly `---` and should contain Yaml records with the fields described below.
 For an example of a file with a formalization entry, see [Q208416.md](_thm/Q208416.md).
 
-* `wikidata`: Wikidata identifier for this theorem (or concept related to the theorem). This is usually the Wikipedia page containing the theorem.
+* `wikidata`: Wikidata identifier for this theorem (or concept related to the theorem). Valid identifiers start with the latter Q followed by a number.
 * `id_suffix` (optional): disambiguates an entry when two theorems have the same wikidata identifier. `X` means an extra theorem on a Wikipedia page (e.g. a generalization or special case), `A`/`B`/... means different theorems on one Wikipedia page that doesn't have a "main" theorem.
-* `msc_classification`: Our best guess of the [MSC-classification](https://msc2020.org/). Please PR a better suggestion!
-* `wikipedia_links`: The exact link used on
-* Then zero or more entries for the formalizations `isabelle`, `hol_light`, `coq`, `lean`, `metamath`, `mizar`
+* `msc_classification`: Our best guess of the [MSC-classification](https://msc2020.org/) of this theorem. Please PR a better suggestion!
+* `wikipedia_links`: list of exact wikipedia links to the relevant page(s). Each link has the format `[[Page name]]` or `[[Wikilink|Displayed name]]`.
+* Then zero or more entries for the formalizations in any of the supported proof assistants (`isabelle`, `hol_light`, `coq`, `lean`, `metamath`, `mizar`). Several formalization entries for one assistant are allowed.
 
-For each proof assistant we record the following information
+For each formalization in each proof assistant, we record the following information
 
-* `status`: `formalized`, `statement`
+* `status`: `formalized` (the proof is formalized), `statement` (just the statement is)
 * `library`: in what library does the formalization appear
-  - S standard library
-  - L main (biggest) mathematical library (afp, hol light outside standard library, mathcomp, mathlib, mml, set.mm)
-  - X external to main or standard library (e.g. a dedicated repository)
-* `url`: a URL pointing to the formalization (or a list collecting a list of theorems for a particular proof assistant).
-* `authors`:  (optional)
+  - "S": standard library
+  - "L": main (biggest) mathematical library (afp, hol light outside standard library, mathcomp, mathlib, mml, set.mm)
+  - "X": external to the main or standard library (e.g. a dedicated repository)
+* `url`: a URL pointing to the formalization
+* `authors`:  list of authors of the formalisation; optional
 * `date`:  (optional). Format: YYYY-MM-DD
 * `comment`: (optional)
 


### PR DESCRIPTION
Having a specification of the file format is great and really helpful!
The current version is sometimes imprecise, sometimes incomplete
(e.g. dangling sentences) and sometimes outdated. Correct all three.

In addition, remove (any implicit mention of) the 'identifiers' field from
the README: these are more unstable; we prefer to track stable URLs
(which point to the respective theorems) rather than identifiers which become
outdated more quickly.

Found while implementing a more typed parser for this, for use in synchronising
this database with a file of formalisations in mathlib.