### PR TITLE
more flexible date field

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,6 @@ For each formalization in each proof assistant, we record the following informat
   - "X": external to the main or standard library (e.g. a dedicated repository)
 * `url`: a URL pointing to the formalization
 * `authors`:  list of authors of the formalisation; optional
-* `date`:  (optional). Format: YYYY or YYYY-MM or YYYY-MM-DD
+* `date`:  (optional). Format: `YYYY`, `YYYY-MM` or `YYYY-MM-DD`
 * `comment`: (optional)
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,6 @@ For each formalization in each proof assistant, we record the following informat
   - "X": external to the main or standard library (e.g. a dedicated repository)
 * `url`: a URL pointing to the formalization
 * `authors`:  list of authors of the formalisation; optional
-* `date`:  (optional). Format: YYYY-MM-DD
+* `date`:  (optional). Format: YYYY or YYYY-MM or YYYY-MM-DD
 * `comment`: (optional)
 


### PR DESCRIPTION
As discussed on the [Lean Zulip](https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/1000-plus.20theorems.20project), it is not reasonable to always expect a precise day, so I added the option to just specify the month and year.

@katjabercic @cverified @grunweg 