### PR TITLE
chore: update Lean formalisations

### DIFF
--- a/_thm/Q1032886.md
+++ b/_thm/Q1032886.md
@@ -2,7 +2,14 @@
 # Hales–Jewett theorem
 
 wikidata: Q1032886
-msc_classification: "05"
+msc_classification: '05'
 wikipedia_links:
-  - "[[Hales–Jewett theorem]]"
+- '[[Hales–Jewett theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1032886
+  authors:
+  - David Wärn
+
 ---

--- a/_thm/Q1033910.md
+++ b/_thm/Q1033910.md
@@ -2,7 +2,14 @@
 # Cantor–Bernstein–Schroeder theorem
 
 wikidata: Q1033910
-msc_classification: "03"
+msc_classification: '03'
 wikipedia_links:
-  - "[[Cantor–Bernstein–Schroeder theorem]]"
+- '[[Cantor–Bernstein–Schroeder theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1033910
+  authors:
+  - Mario Carneiro
+
 ---

--- a/_thm/Q1038716.md
+++ b/_thm/Q1038716.md
@@ -2,7 +2,12 @@
 # Identity theorem
 
 wikidata: Q1038716
-msc_classification: "30"
+msc_classification: '30'
 wikipedia_links:
-  - "[[Identity theorem]]"
+- '[[Identity theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1038716
+
 ---

--- a/_thm/Q1047749.md
+++ b/_thm/Q1047749.md
@@ -2,7 +2,14 @@
 # Turán's theorem
 
 wikidata: Q1047749
-msc_classification: "05"
+msc_classification: '05'
 wikipedia_links:
-  - "[[Turán's theorem]]"
+- '[[Turán''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1047749
+  authors:
+  - Jeremy Tan
+
 ---

--- a/_thm/Q1050203.md
+++ b/_thm/Q1050203.md
@@ -2,7 +2,12 @@
 # Cantor's intersection theorem
 
 wikidata: Q1050203
-msc_classification: "26"
+msc_classification: '26'
 wikipedia_links:
-  - "[[Cantor's intersection theorem]]"
+- '[[Cantor''s intersection theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1050203
+
 ---

--- a/_thm/Q1050932.md
+++ b/_thm/Q1050932.md
@@ -2,7 +2,14 @@
 # Hartogs's theorem
 
 wikidata: Q1050932
-msc_classification: "30"
+msc_classification: '30'
 wikipedia_links:
-  - "[[Hartogs's theorem]]"
+- '[[Hartogs''s theorem]]'
+lean:
+- status: formalized
+  library: X
+  url: https://leanprover-community.github.io/1000.html#Q1050932
+  authors:
+  - Geoffrey Irving
+
 ---

--- a/_thm/Q1052678.md
+++ b/_thm/Q1052678.md
@@ -2,7 +2,12 @@
 # Baire category theorem
 
 wikidata: Q1052678
-msc_classification: "54"
+msc_classification: '54'
 wikipedia_links:
-  - "[[Baire category theorem]]"
+- '[[Baire category theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1052678
+
 ---

--- a/_thm/Q1057919.md
+++ b/_thm/Q1057919.md
@@ -2,7 +2,12 @@
 # Sylow theorems
 
 wikidata: Q1057919
-msc_classification: "20"
+msc_classification: '20'
 wikipedia_links:
-  - "[[Sylow theorems]]"
+- '[[Sylow theorems]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1057919
+
 ---

--- a/_thm/Q1065257.md
+++ b/_thm/Q1065257.md
@@ -2,7 +2,12 @@
 # Squeeze theorem
 
 wikidata: Q1065257
-msc_classification: "26"
+msc_classification: '26'
 wikipedia_links:
-  - "[[Squeeze theorem]]"
+- '[[Squeeze theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1065257
+
 ---

--- a/_thm/Q1065966.md
+++ b/_thm/Q1065966.md
@@ -2,7 +2,12 @@
 # Isomorphism theorem
 
 wikidata: Q1065966
-msc_classification: "16"
+msc_classification: '16'
 wikipedia_links:
-  - "[[Isomorphism theorem]]"
+- '[[Isomorphism theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1065966
+
 ---

--- a/_thm/Q1067156.md
+++ b/_thm/Q1067156.md
@@ -2,7 +2,12 @@
 # Dominated convergence theorem
 
 wikidata: Q1067156
-msc_classification: "28"
+msc_classification: '28'
 wikipedia_links:
-  - "[[Dominated convergence theorem]]"
+- '[[Dominated convergence theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1067156
+
 ---

--- a/_thm/Q1067156X.md
+++ b/_thm/Q1067156X.md
@@ -2,9 +2,13 @@
 # Bounded convergence theorem
 
 wikidata: Q1067156
-# dominated convergence theorem
 id_suffix: X
-msc_classification: "28"
+msc_classification: '28'
 wikipedia_links:
-  - "[[Bounded convergence theorem]]"
+- '[[Bounded convergence theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1067156X
+
 ---

--- a/_thm/Q1068085.md
+++ b/_thm/Q1068085.md
@@ -2,7 +2,12 @@
 # Closed graph theorem
 
 wikidata: Q1068085
-msc_classification: "46"
+msc_classification: '46'
 wikipedia_links:
-  - "[[Closed graph theorem]]"
+- '[[Closed graph theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1068085
+
 ---

--- a/_thm/Q1068283.md
+++ b/_thm/Q1068283.md
@@ -2,7 +2,12 @@
 # Löwenheim–Skolem theorem
 
 wikidata: Q1068283
-msc_classification: "03"
+msc_classification: '03'
 wikipedia_links:
-  - "[[Löwenheim–Skolem theorem]]"
+- '[[Löwenheim–Skolem theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1068283
+
 ---

--- a/_thm/Q1068976.md
+++ b/_thm/Q1068976.md
@@ -1,8 +1,13 @@
 ---
-# Hilbert's Nullstellensatz (theorem of zeroes)
+# Hilbert's Nullstellensatz
 
 wikidata: Q1068976
-msc_classification: "14"
+msc_classification: '14'
 wikipedia_links:
-  - "[[Hilbert's Nullstellensatz]] (theorem of zeroes)"
+- '[[Hilbert''s Nullstellensatz]] (theorem of zeroes)'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1068976
+
 ---

--- a/_thm/Q1082910.md
+++ b/_thm/Q1082910.md
@@ -2,7 +2,15 @@
 # Euler's partition theorem
 
 wikidata: Q1082910
-msc_classification: "11"
+msc_classification: '11'
 wikipedia_links:
-  - "[[Integer partition#Odd parts and distinct parts|Euler's partition theorem]]"
+- '[[Integer partition#Odd parts and distinct parts|Euler''s partition theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1082910
+  authors:
+  - Bhavik Mehta
+  - Aaron Anderson
+
 ---

--- a/_thm/Q1095330.md
+++ b/_thm/Q1095330.md
@@ -2,7 +2,12 @@
 # Apéry's theorem
 
 wikidata: Q1095330
-msc_classification: "11"
+msc_classification: '11'
 wikipedia_links:
-  - "[[Apéry's theorem]]"
+- '[[Apéry''s theorem]]'
+lean:
+- status: formalized
+  library: X
+  url: https://leanprover-community.github.io/1000.html#Q1095330
+
 ---

--- a/_thm/Q1097021.md
+++ b/_thm/Q1097021.md
@@ -2,7 +2,16 @@
 # Minkowski's theorem
 
 wikidata: Q1097021
-msc_classification: "11"
+msc_classification: '11'
 wikipedia_links:
-  - "[[Minkowski's theorem]]"
+- '[[Minkowski''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1097021
+  authors:
+  - Alex J. Best
+  - Yaël Dillies
+  date: 2021
+
 ---

--- a/_thm/Q11352023.md
+++ b/_thm/Q11352023.md
@@ -2,7 +2,15 @@
 # Vitali convergence theorem
 
 wikidata: Q11352023
-msc_classification: "28"
+msc_classification: '28'
 wikipedia_links:
-  - "[[Vitali convergence theorem]]"
+- '[[Vitali convergence theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q11352023
+  authors:
+  - Igor Khavkine
+  date: 2024
+
 ---

--- a/_thm/Q1137014.md
+++ b/_thm/Q1137014.md
@@ -2,7 +2,12 @@
 # Tychonoff's theorem
 
 wikidata: Q1137014
-msc_classification: "54"
+msc_classification: '54'
 wikipedia_links:
-  - "[[Tychonoff's theorem]]"
+- '[[Tychonoff''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1137014
+
 ---

--- a/_thm/Q1137206.md
+++ b/_thm/Q1137206.md
@@ -2,7 +2,14 @@
 # Taylor's theorem
 
 wikidata: Q1137206
-msc_classification: "26"
+msc_classification: '26'
 wikipedia_links:
-  - "[[Taylor's theorem]]"
+- '[[Taylor''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1137206
+  authors:
+  - Moritz Doll
+
 ---

--- a/_thm/Q1139041.md
+++ b/_thm/Q1139041.md
@@ -2,7 +2,12 @@
 # Cauchy's theorem
 
 wikidata: Q1139041
-msc_classification: "20"
+msc_classification: '20'
 wikipedia_links:
-  - "[[Cauchy's theorem (group theory)|Cauchy's theorem]]"
+- '[[Cauchy''s theorem (group theory)|Cauchy''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1139041
+
 ---

--- a/_thm/Q1144897.md
+++ b/_thm/Q1144897.md
@@ -2,7 +2,15 @@
 # Brouwer fixed-point theorem
 
 wikidata: Q1144897
-msc_classification: "54"
+msc_classification: '54'
 wikipedia_links:
-  - "[[Brouwer fixed-point theorem]]"
+- '[[Brouwer fixed-point theorem]]'
+lean:
+- status: formalized
+  library: X
+  url: https://leanprover-community.github.io/1000.html#Q1144897
+  authors:
+  - Brendan Seamas Murphy
+  comment: in Lean 3
+
 ---

--- a/_thm/Q1149022.md
+++ b/_thm/Q1149022.md
@@ -2,7 +2,12 @@
 # Fubini's theorem
 
 wikidata: Q1149022
-msc_classification: "28"
+msc_classification: '28'
 wikipedia_links:
-  - "[[Fubini's theorem]]"
+- '[[Fubini''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1149022
+
 ---

--- a/_thm/Q1149458.md
+++ b/_thm/Q1149458.md
@@ -2,7 +2,12 @@
 # Compactness theorem
 
 wikidata: Q1149458
-msc_classification: "03"
+msc_classification: '03'
 wikipedia_links:
-  - "[[Compactness theorem]]"
+- '[[Compactness theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1149458
+
 ---

--- a/_thm/Q11518.md
+++ b/_thm/Q11518.md
@@ -2,7 +2,14 @@
 # Pythagorean theorem
 
 wikidata: Q11518
-msc_classification: "51"
+msc_classification: '51'
 wikipedia_links:
-  - "[[Pythagorean theorem]]"
+- '[[Pythagorean theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q11518
+  authors:
+  - Joseph Myers
+
 ---

--- a/_thm/Q1153584.md
+++ b/_thm/Q1153584.md
@@ -2,7 +2,12 @@
 # Monotone convergence theorem
 
 wikidata: Q1153584
-msc_classification: "26"
+msc_classification: '26'
 wikipedia_links:
-  - "[[Monotone convergence theorem]]"
+- '[[Monotone convergence theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1153584
+
 ---

--- a/_thm/Q1186808.md
+++ b/_thm/Q1186808.md
@@ -2,7 +2,12 @@
 # Lucas's theorem
 
 wikidata: Q1186808
-msc_classification: "11"
+msc_classification: '11'
 wikipedia_links:
-  - "[[Lucas's theorem]]"
+- '[[Lucas''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1186808
+
 ---

--- a/_thm/Q1187646.md
+++ b/_thm/Q1187646.md
@@ -2,7 +2,12 @@
 # Fundamental theorem on homomorphisms
 
 wikidata: Q1187646
-msc_classification: "16"
+msc_classification: '16'
 wikipedia_links:
-  - "[[Fundamental theorem on homomorphisms]]"
+- '[[Fundamental theorem on homomorphisms]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1187646
+
 ---

--- a/_thm/Q1188392.md
+++ b/_thm/Q1188392.md
@@ -2,7 +2,12 @@
 # Zeckendorf's theorem
 
 wikidata: Q1188392
-msc_classification: "11"
+msc_classification: '11'
 wikipedia_links:
-  - "[[Zeckendorf's theorem]]"
+- '[[Zeckendorf''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1188392
+
 ---

--- a/_thm/Q1191319.md
+++ b/_thm/Q1191319.md
@@ -2,7 +2,12 @@
 # Radon–Nikodym theorem
 
 wikidata: Q1191319
-msc_classification: "28"
+msc_classification: '28'
 wikipedia_links:
-  - "[[Radon–Nikodym theorem]]"
+- '[[Radon–Nikodym theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1191319
+
 ---

--- a/_thm/Q1191709.md
+++ b/_thm/Q1191709.md
@@ -2,7 +2,14 @@
 # Egorov's theorem
 
 wikidata: Q1191709
-msc_classification: "28"
+msc_classification: '28'
 wikipedia_links:
-  - "[[Egorov's theorem]]"
+- '[[Egorov''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1191709
+  authors:
+  - Kexing Ying
+
 ---

--- a/_thm/Q1194053.md
+++ b/_thm/Q1194053.md
@@ -2,7 +2,13 @@
 # Metrization theorems
 
 wikidata: Q1194053
-msc_classification: "54"
+msc_classification: '54'
 wikipedia_links:
-  - "[[Metrization theorems]]"
+- '[[Metrization theorems]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1194053
+  comment: Urysohn's metrization theorem (only)
+
 ---

--- a/_thm/Q1217677.md
+++ b/_thm/Q1217677.md
@@ -2,7 +2,15 @@
 # Fundamental theorem of calculus
 
 wikidata: Q1217677
-msc_classification: "26"
+msc_classification: '26'
 wikipedia_links:
-  - "[[Fundamental theorem of calculus]]"
+- '[[Fundamental theorem of calculus]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1217677
+  authors:
+  - Yury G. Kudryashov (first)
+  - Benjamin Davidson (second)
+
 ---

--- a/_thm/Q1243340.md
+++ b/_thm/Q1243340.md
@@ -2,7 +2,15 @@
 # Birkhoff–Von Neumann theorem
 
 wikidata: Q1243340
-msc_classification: "15"
+msc_classification: '15'
 wikipedia_links:
-  - "[[Birkhoff–Von Neumann theorem]]"
+- '[[Birkhoff–Von Neumann theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1243340
+  authors:
+  - Bhavik Mehta
+  date: 2024
+
 ---

--- a/_thm/Q1259814.md
+++ b/_thm/Q1259814.md
@@ -2,7 +2,12 @@
 # Nielsen–Schreier theorem
 
 wikidata: Q1259814
-msc_classification: "20"
+msc_classification: '20'
 wikipedia_links:
-  - "[[Nielsen–Schreier theorem]]"
+- '[[Nielsen–Schreier theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1259814
+
 ---

--- a/_thm/Q1306095.md
+++ b/_thm/Q1306095.md
@@ -2,7 +2,13 @@
 # Whitney embedding theorem
 
 wikidata: Q1306095
-msc_classification: "57"
+msc_classification: '57'
 wikipedia_links:
-  - "[[Whitney embedding theorem]]"
+- '[[Whitney embedding theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1306095
+  comment: 'baby version: for compact manifolds; embedding into some *n*'
+
 ---

--- a/_thm/Q132469.md
+++ b/_thm/Q132469.md
@@ -2,7 +2,13 @@
 # Fermat's Last Theorem
 
 wikidata: Q132469
-msc_classification: "11"
+msc_classification: '11'
 wikipedia_links:
-  - "[[Fermat's Last Theorem]]"
+- '[[Fermat''s Last Theorem]]'
+lean:
+- status: statement
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q132469
+  comment: Formalisation of the proof is on-going in https://imperialcollegelondon.github.io/FLT/.
+
 ---

--- a/_thm/Q1346677.md
+++ b/_thm/Q1346677.md
@@ -2,7 +2,12 @@
 # Tietze extension theorem
 
 wikidata: Q1346677
-msc_classification: "54"
+msc_classification: '54'
 wikipedia_links:
-  - "[[Tietze extension theorem]]"
+- '[[Tietze extension theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1346677
+
 ---

--- a/_thm/Q137164.md
+++ b/_thm/Q137164.md
@@ -2,7 +2,15 @@
 # Besicovitch covering theorem
 
 wikidata: Q137164
-msc_classification: "26"
+msc_classification: '26'
 wikipedia_links:
-  - "[[Besicovitch covering theorem]]"
+- '[[Besicovitch covering theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q137164
+  authors:
+  - Sébastien Gouëzel
+  date: 2021
+
 ---

--- a/_thm/Q1426292.md
+++ b/_thm/Q1426292.md
@@ -2,7 +2,15 @@
 # Banach–Steinhaus theorem
 
 wikidata: Q1426292
-msc_classification: "46"
+msc_classification: '46'
 wikipedia_links:
-  - "[[Banach–Steinhaus theorem]]"
+- '[[Banach–Steinhaus theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1426292
+  authors:
+  - Jireh Loreaux
+  date: 2021
+
 ---

--- a/_thm/Q1477053.md
+++ b/_thm/Q1477053.md
@@ -2,7 +2,12 @@
 # Arzelà–Ascoli theorem
 
 wikidata: Q1477053
-msc_classification: "46"
+msc_classification: '46'
 wikipedia_links:
-  - "[[Arzelà–Ascoli theorem]]"
+- '[[Arzelà–Ascoli theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1477053
+
 ---

--- a/_thm/Q1506253.md
+++ b/_thm/Q1506253.md
@@ -2,7 +2,14 @@
 # Euclid's theorem
 
 wikidata: Q1506253
-msc_classification: "11"
+msc_classification: '11'
 wikipedia_links:
-  - "[[Euclid's theorem]]"
+- '[[Euclid''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1506253
+  authors:
+  - Jeremy Avigad
+
 ---

--- a/_thm/Q1542114.md
+++ b/_thm/Q1542114.md
@@ -2,7 +2,14 @@
 # Bézout's theorem
 
 wikidata: Q1542114
-msc_classification: "14"
+msc_classification: '14'
 wikipedia_links:
-  - "[[Bézout's theorem]]"
+- '[[Bézout''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1542114
+  authors:
+  - mathlib
+
 ---

--- a/_thm/Q1566341.md
+++ b/_thm/Q1566341.md
@@ -2,7 +2,14 @@
 # Hindman's theorem
 
 wikidata: Q1566341
-msc_classification: "05"
+msc_classification: '05'
 wikipedia_links:
-  - "[[Hindman's theorem]]"
+- '[[Hindman''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1566341
+  authors:
+  - David Wärn
+
 ---

--- a/_thm/Q1568811.md
+++ b/_thm/Q1568811.md
@@ -2,7 +2,15 @@
 # Hahn decomposition theorem
 
 wikidata: Q1568811
-msc_classification: "28"
+msc_classification: '28'
 wikipedia_links:
-  - "[[Hahn decomposition theorem]]"
+- '[[Hahn decomposition theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1568811
+  authors:
+  - Kexing Ying
+  date: 2021
+
 ---

--- a/_thm/Q16251580.md
+++ b/_thm/Q16251580.md
@@ -2,7 +2,15 @@
 # Matiyasevich's theorem
 
 wikidata: Q16251580
-msc_classification: "03"
+msc_classification: '03'
 wikipedia_links:
-  - "[[Matiyasevich's theorem]]"
+- '[[Matiyasevich''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q16251580
+  authors:
+  - Mario Carneiro
+  date: 2017
+
 ---

--- a/_thm/Q1632433.md
+++ b/_thm/Q1632433.md
@@ -2,7 +2,15 @@
 # Helly's theorem
 
 wikidata: Q1632433
-msc_classification: "52"
+msc_classification: '52'
 wikipedia_links:
-  - "[[Helly's theorem]]"
+- '[[Helly''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1632433
+  authors:
+  - Vasily Nesterov
+  date: 2023
+
 ---

--- a/_thm/Q1687147.md
+++ b/_thm/Q1687147.md
@@ -2,7 +2,15 @@
 # Sprague–Grundy theorem
 
 wikidata: Q1687147
-msc_classification: "05"
+msc_classification: '05'
 wikipedia_links:
-  - "[[Sprague–Grundy theorem]]"
+- '[[Sprague–Grundy theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1687147
+  authors:
+  - Fox Thomson
+  date: 2020
+
 ---

--- a/_thm/Q17005116.md
+++ b/_thm/Q17005116.md
@@ -2,7 +2,15 @@
 # Birkhoff's representation theorem
 
 wikidata: Q17005116
-msc_classification: "06"
+msc_classification: '06'
 wikipedia_links:
-  - "[[Birkhoff's representation theorem]]"
+- '[[Birkhoff''s representation theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q17005116
+  authors:
+  - Yaël Dillies
+  date: 2022
+
 ---

--- a/_thm/Q172298.md
+++ b/_thm/Q172298.md
@@ -2,7 +2,12 @@
 # Lasker–Noether theorem
 
 wikidata: Q172298
-msc_classification: "13"
+msc_classification: '13'
 wikipedia_links:
-  - "[[Lasker–Noether theorem]]"
+- '[[Lasker–Noether theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q172298
+
 ---

--- a/_thm/Q1752621.md
+++ b/_thm/Q1752621.md
@@ -2,7 +2,12 @@
 # Sylvester's law of inertia
 
 wikidata: Q1752621
-msc_classification: "11"
+msc_classification: '11'
 wikipedia_links:
-  - "[[Sylvester's law of inertia]]"
+- '[[Sylvester''s law of inertia]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1752621
+
 ---

--- a/_thm/Q179208.md
+++ b/_thm/Q179208.md
@@ -2,7 +2,15 @@
 # Cayley's theorem
 
 wikidata: Q179208
-msc_classification: "20"
+msc_classification: '20'
 wikipedia_links:
-  - "[[Cayley's theorem]]"
+- '[[Cayley''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q179208
+  authors:
+  - Eric Wieser
+  date: 2021
+
 ---

--- a/_thm/Q180345.md
+++ b/_thm/Q180345.md
@@ -2,7 +2,12 @@
 # Rational root theorem
 
 wikidata: Q180345
-msc_classification: "12"
+msc_classification: '12'
 wikipedia_links:
-  - "[[Rational root theorem]]"
+- '[[Rational root theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q180345
+
 ---

--- a/_thm/Q180345X.md
+++ b/_thm/Q180345X.md
@@ -2,9 +2,13 @@
 # Integral root theorem
 
 wikidata: Q180345
-# rational root theorem
 id_suffix: X
-msc_classification: "12"
+msc_classification: '12'
 wikipedia_links:
-  - "[[Integral root theorem]]"
+- '[[Integral root theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q180345X
+
 ---

--- a/_thm/Q1816952.md
+++ b/_thm/Q1816952.md
@@ -2,7 +2,12 @@
 # Schur's lemma
 
 wikidata: Q1816952
-msc_classification: "20"
+msc_classification: '20'
 wikipedia_links:
-  - "[[Schur's lemma]]"
+- '[[Schur''s lemma]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1816952
+
 ---

--- a/_thm/Q18206266.md
+++ b/_thm/Q18206266.md
@@ -2,7 +2,14 @@
 # Euclid–Euler theorem
 
 wikidata: Q18206266
-msc_classification: "11"
+msc_classification: '11'
 wikipedia_links:
-  - "[[Euclid–Euler theorem]]"
+- '[[Euclid–Euler theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q18206266
+  authors:
+  - Aaron Anderson
+
 ---

--- a/_thm/Q182505.md
+++ b/_thm/Q182505.md
@@ -2,7 +2,15 @@
 # Bayes' theorem
 
 wikidata: Q182505
-msc_classification: "60"
+msc_classification: '60'
 wikipedia_links:
-  - "[[Bayes' theorem]]"
+- '[[Bayes'' theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q182505
+  authors:
+  - Rishikesh Vaishnav
+  date: 2022
+
 ---

--- a/_thm/Q188295.md
+++ b/_thm/Q188295.md
@@ -2,7 +2,15 @@
 # Fermat's little theorem
 
 wikidata: Q188295
-msc_classification: "11"
+msc_classification: '11'
 wikipedia_links:
-  - "[[Fermat's little theorem]]"
+- '[[Fermat''s little theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q188295
+  authors:
+  - Aaron Anderson
+  date: 2020
+
 ---

--- a/_thm/Q189136.md
+++ b/_thm/Q189136.md
@@ -2,7 +2,15 @@
 # Mean value theorem
 
 wikidata: Q189136
-msc_classification: "26"
+msc_classification: '26'
 wikipedia_links:
-  - "[[Mean value theorem]]"
+- '[[Mean value theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q189136
+  authors:
+  - Yury G. Kudryashov
+  date: 2019
+
 ---

--- a/_thm/Q1893717.md
+++ b/_thm/Q1893717.md
@@ -2,7 +2,12 @@
 # Rice's theorem
 
 wikidata: Q1893717
-msc_classification: "68"
+msc_classification: '68'
 wikipedia_links:
-  - "[[Rice's theorem]]"
+- '[[Rice''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1893717
+
 ---

--- a/_thm/Q190556.md
+++ b/_thm/Q190556.md
@@ -2,7 +2,15 @@
 # De Moivre's theorem
 
 wikidata: Q190556
-msc_classification: "30"
+msc_classification: '30'
 wikipedia_links:
-  - "[[De Moivre's formula|De Moivre's theorem]]"
+- '[[De Moivre''s formula|De Moivre''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q190556
+  authors:
+  - Abhimanyu Pallavi Sudhir
+  date: 2019
+
 ---

--- a/_thm/Q191693.md
+++ b/_thm/Q191693.md
@@ -2,7 +2,15 @@
 # Lebesgue's decomposition theorem
 
 wikidata: Q191693
-msc_classification: "54"
+msc_classification: '54'
 wikipedia_links:
-  - "[[Lebesgue's decomposition theorem]]"
+- '[[Lebesgue''s decomposition theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q191693
+  authors:
+  - Kexing Ying
+  date: 2021
+
 ---

--- a/_thm/Q192760.md
+++ b/_thm/Q192760.md
@@ -2,7 +2,15 @@
 # Fundamental theorem of algebra
 
 wikidata: Q192760
-msc_classification: "30"
+msc_classification: '30'
 wikipedia_links:
-  - "[[Fundamental theorem of algebra]]"
+- '[[Fundamental theorem of algebra]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q192760
+  authors:
+  - Chris Hughes
+  date: 2019
+
 ---

--- a/_thm/Q193286.md
+++ b/_thm/Q193286.md
@@ -2,7 +2,15 @@
 # Rolle's theorem
 
 wikidata: Q193286
-msc_classification: "26"
+msc_classification: '26'
 wikipedia_links:
-  - "[[Rolle's theorem]]"
+- '[[Rolle''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q193286
+  authors:
+  - Yury G. Kudryashov
+  date: 2019
+
 ---

--- a/_thm/Q193878.md
+++ b/_thm/Q193878.md
@@ -2,8 +2,13 @@
 # Chinese remainder theorem
 
 wikidata: Q193878
-msc_classification: "11"
+msc_classification: '11'
 wikipedia_links:
-  - "[[Chinese remainder theorem]]"
-  - "[[Linear congruence theorem]]"
+- '[[Chinese remainder theorem]]'
+- '[[Linear congruence theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q193878
+
 ---

--- a/_thm/Q200787.md
+++ b/_thm/Q200787.md
@@ -2,7 +2,14 @@
 # Gödel's incompleteness theorem
 
 wikidata: Q200787
-msc_classification: "03"
+msc_classification: '03'
 wikipedia_links:
-  - "[[Gödel's incompleteness theorem]]"
+- '[[Gödel''s incompleteness theorem]]'
+lean:
+- status: formalized
+  library: X
+  url: https://leanprover-community.github.io/1000.html#Q200787
+  authors:
+  - Shogo Saito
+
 ---

--- a/_thm/Q2027347.md
+++ b/_thm/Q2027347.md
@@ -2,7 +2,15 @@
 # Optional stopping theorem
 
 wikidata: Q2027347
-msc_classification: "60"
+msc_classification: '60'
 wikipedia_links:
-  - "[[Optional stopping theorem]]"
+- '[[Optional stopping theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q2027347
+  authors:
+  - Kexing Ying, Rémy Degenne
+  date: 2022
+
 ---

--- a/_thm/Q203565.md
+++ b/_thm/Q203565.md
@@ -2,7 +2,15 @@
 # Solutions of a general cubic equation
 
 wikidata: Q203565
-msc_classification: "12"
+msc_classification: '12'
 wikipedia_links:
-  - "[[Cubic equation|Solutions of a general cubic equation]]"
+- '[[Cubic equation|Solutions of a general cubic equation]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q203565
+  authors:
+  - Jeoff Lee
+  date: 2022
+
 ---

--- a/_thm/Q208416.md
+++ b/_thm/Q208416.md
@@ -2,14 +2,16 @@
 # Independence of the continuum hypothesis
 
 wikidata: Q208416
-msc_classification: "03"
+msc_classification: '03'
 wikipedia_links:
-  - "[[Continuum hypothesis#Independence from ZFC|Independence of the continuum hypothesis]]"
-
+- '[[Continuum hypothesis#Independence from ZFC|Independence of the continuum hypothesis]]'
 lean:
-  - status: formalized
-    library: X
-    url: "https://github.com/flypitch/flypitch"
-    authors: [Floris van Doorn, Jesse Michael Han]
-    date: 2019-09-17
+- status: formalized
+  library: X
+  url: https://leanprover-community.github.io/1000.html#Q208416
+  authors:
+  - Floris van Doorn
+  - Jesse Michael Han
+  date: 2019-09-17
+
 ---

--- a/_thm/Q2093886.md
+++ b/_thm/Q2093886.md
@@ -2,7 +2,12 @@
 # Primitive element theorem
 
 wikidata: Q2093886
-msc_classification: "12"
+msc_classification: '12'
 wikipedia_links:
-  - "[[Primitive element theorem]]"
+- '[[Primitive element theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q2093886
+
 ---

--- a/_thm/Q220680.md
+++ b/_thm/Q220680.md
@@ -2,7 +2,12 @@
 # Banach fixed-point theorem
 
 wikidata: Q220680
-msc_classification: "54"
+msc_classification: '54'
 wikipedia_links:
-  - "[[Banach fixed-point theorem]]"
+- '[[Banach fixed-point theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q220680
+
 ---

--- a/_thm/Q2226786.md
+++ b/_thm/Q2226786.md
@@ -2,7 +2,15 @@
 # Sperner's theorem
 
 wikidata: Q2226786
-msc_classification: "05"
+msc_classification: '05'
 wikipedia_links:
-  - "[[Sperner's theorem]]"
+- '[[Sperner''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q2226786
+  authors:
+  - Bhavik Mehta, Alena Gusakov, Yaël Dillies
+  date: 2022
+
 ---

--- a/_thm/Q2226800.md
+++ b/_thm/Q2226800.md
@@ -2,7 +2,15 @@
 # Schur–Zassenhaus theorem
 
 wikidata: Q2226800
-msc_classification: "20"
+msc_classification: '20'
 wikipedia_links:
-  - "[[Schur–Zassenhaus theorem]]"
+- '[[Schur–Zassenhaus theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q2226800
+  authors:
+  - Thomas Browning
+  date: 2021
+
 ---

--- a/_thm/Q2253746.md
+++ b/_thm/Q2253746.md
@@ -2,7 +2,15 @@
 # Bertrand's ballot theorem
 
 wikidata: Q2253746
-msc_classification: "60"
+msc_classification: '60'
 wikipedia_links:
-  - "[[Bertrand's ballot theorem]]"
+- '[[Bertrand''s ballot theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q2253746
+  authors:
+  - Bhavik Mehta
+  - Kexing Ying
+
 ---

--- a/_thm/Q2275191.md
+++ b/_thm/Q2275191.md
@@ -2,7 +2,15 @@
 # Lebesgue differentiation theorem
 
 wikidata: Q2275191
-msc_classification: "26"
+msc_classification: '26'
 wikipedia_links:
-  - "[[Lebesgue differentiation theorem]]"
+- '[[Lebesgue differentiation theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q2275191
+  authors:
+  - Sébastien Gouëzel
+  date: 2021
+
 ---

--- a/_thm/Q22952648.md
+++ b/_thm/Q22952648.md
@@ -2,7 +2,14 @@
 # Uncountability of the continuum
 
 wikidata: Q22952648
-msc_classification: "03"
+msc_classification: '03'
 wikipedia_links:
-  - "[[Cardinality of the continuum#Uncountability|Uncountability of the continuum]]"
+- '[[Cardinality of the continuum#Uncountability|Uncountability of the continuum]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q22952648
+  authors:
+  - Floris van Doorn
+
 ---

--- a/_thm/Q245098.md
+++ b/_thm/Q245098.md
@@ -2,7 +2,15 @@
 # Intermediate value theorem
 
 wikidata: Q245098
-msc_classification: "26"
+msc_classification: '26'
 wikipedia_links:
-  - "[[Intermediate value theorem]]"
+- '[[Intermediate value theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q245098
+  authors:
+  - Rob Lewis
+  - Chris Hughes
+
 ---

--- a/_thm/Q2471737.md
+++ b/_thm/Q2471737.md
@@ -2,7 +2,12 @@
 # Carathéodory's theorem
 
 wikidata: Q2471737
-msc_classification: "52"
+msc_classification: '52'
 wikipedia_links:
-  - "[[Carathéodory's theorem (convex hull)|Carathéodory's theorem]]"
+- '[[Carathéodory''s theorem (convex hull)|Carathéodory''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q2471737
+
 ---

--- a/_thm/Q2525646.md
+++ b/_thm/Q2525646.md
@@ -2,7 +2,12 @@
 # Jordan–Hölder theorem
 
 wikidata: Q2525646
-msc_classification: "20"
+msc_classification: '20'
 wikipedia_links:
-  - "[[Jordan–Hölder theorem]]"
+- '[[Jordan–Hölder theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q2525646
+
 ---

--- a/_thm/Q253214.md
+++ b/_thm/Q253214.md
@@ -2,7 +2,12 @@
 # Heine–Borel theorem
 
 wikidata: Q253214
-msc_classification: "26"
+msc_classification: '26'
 wikipedia_links:
-  - "[[Heine–Borel theorem]]"
+- '[[Heine–Borel theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q253214
+
 ---

--- a/_thm/Q257387.md
+++ b/_thm/Q257387.md
@@ -2,7 +2,15 @@
 # Vitali theorem
 
 wikidata: Q257387
-msc_classification: "28"
+msc_classification: '28'
 wikipedia_links:
-  - "[[Vitali set|Vitali theorem]]"
+- '[[Vitali set|Vitali theorem]]'
+lean:
+- status: formalized
+  library: X
+  url: https://leanprover-community.github.io/1000.html#Q257387
+  authors:
+  - Ching-Tsun Chou
+  comment: mathlib4 pull request at https://github.com/leanprover-community/mathlib4/pull/20722
+
 ---

--- a/_thm/Q258374.md
+++ b/_thm/Q258374.md
@@ -2,7 +2,13 @@
 # Carathéodory's theorem
 
 wikidata: Q258374
-msc_classification: "28"
+msc_classification: '28'
 wikipedia_links:
-  - "[[Carathéodory's theorem (measure theory)|Carathéodory's theorem]]"
+- '[[Carathéodory''s theorem (measure theory)|Carathéodory''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q258374
+  comment: Hard to say what exactly is meant.
+
 ---

--- a/_thm/Q26708.md
+++ b/_thm/Q26708.md
@@ -2,7 +2,14 @@
 # Binomial theorem
 
 wikidata: Q26708
-msc_classification: "05"
+msc_classification: '05'
 wikipedia_links:
-  - "[[Binomial theorem]]"
+- '[[Binomial theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q26708
+  authors:
+  - Chris Hughes
+
 ---

--- a/_thm/Q276082.md
+++ b/_thm/Q276082.md
@@ -2,7 +2,14 @@
 # Wilson's theorem
 
 wikidata: Q276082
-msc_classification: "11"
+msc_classification: '11'
 wikipedia_links:
-  - "[[Wilson's theorem]]"
+- '[[Wilson''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q276082
+  authors:
+  - Chris Hughes
+
 ---

--- a/_thm/Q288465.md
+++ b/_thm/Q288465.md
@@ -2,7 +2,12 @@
 # Orbit-stabilizer theorem
 
 wikidata: Q288465
-msc_classification: "20"
+msc_classification: '20'
 wikipedia_links:
-  - "[[Orbit-stabilizer theorem]]"
+- '[[Orbit-stabilizer theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q288465
+
 ---

--- a/_thm/Q2919401.md
+++ b/_thm/Q2919401.md
@@ -2,7 +2,17 @@
 # Ostrowski's theorem
 
 wikidata: Q2919401
-msc_classification: "11"
+msc_classification: '11'
 wikipedia_links:
-  - "[[Ostrowski's theorem]]"
+- '[[Ostrowski''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q2919401
+  authors:
+  - David Kurniadi Angdinata, Fabrizio Barroero, Laura Capuano, Nirvana Coppola, María
+    Inés de Frutos-Fernández, Sam van Gool, Silvain Rideau-Kikuchi, Amos Turchet,
+    Francesco Veneziano
+  date: 2024
+
 ---

--- a/_thm/Q303402.md
+++ b/_thm/Q303402.md
@@ -2,7 +2,12 @@
 # Rank–nullity theorem
 
 wikidata: Q303402
-msc_classification: "15"
+msc_classification: '15'
 wikipedia_links:
-  - "[[Rank–nullity theorem]]"
+- '[[Rank–nullity theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q303402
+
 ---

--- a/_thm/Q318767.md
+++ b/_thm/Q318767.md
@@ -2,7 +2,14 @@
 # Abel's theorem
 
 wikidata: Q318767
-msc_classification: "26"
+msc_classification: '26'
 wikipedia_links:
-  - "[[Abel's theorem]]"
+- '[[Abel''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q318767
+  authors:
+  - Jeremy Tan
+
 ---

--- a/_thm/Q3229352.md
+++ b/_thm/Q3229352.md
@@ -2,7 +2,15 @@
 # Vitali covering theorem
 
 wikidata: Q3229352
-msc_classification: "28"
+msc_classification: '28'
 wikipedia_links:
-  - "[[Vitali covering theorem]]"
+- '[[Vitali covering theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q3229352
+  authors:
+  - Sébastien Gouëzel
+  date: 2021
+
 ---

--- a/_thm/Q33481.md
+++ b/_thm/Q33481.md
@@ -2,7 +2,15 @@
 # Arrow's impossibility theorem
 
 wikidata: Q33481
-msc_classification: "91"
+msc_classification: '91'
 wikipedia_links:
-  - "[[Arrow's impossibility theorem]]"
+- '[[Arrow''s impossibility theorem]]'
+lean:
+- status: formalized
+  library: X
+  url: https://leanprover-community.github.io/1000.html#Q33481
+  authors:
+  - Benjamin Davidson, Andrew Souther
+  date: 2021
+
 ---

--- a/_thm/Q3526996.md
+++ b/_thm/Q3526996.md
@@ -2,7 +2,15 @@
 # Kolmogorov extension theorem
 
 wikidata: Q3526996
-msc_classification: "60"
+msc_classification: '60'
 wikipedia_links:
-  - "[[Kolmogorov extension theorem]]"
+- '[[Kolmogorov extension theorem]]'
+lean:
+- status: formalized
+  library: X
+  url: https://leanprover-community.github.io/1000.html#Q3526996
+  authors:
+  - Rémy Degenne, Peter Pfaffelhuber
+  date: 2023
+
 ---

--- a/_thm/Q3527102.md
+++ b/_thm/Q3527102.md
@@ -2,7 +2,15 @@
 # Kruskal–Katona theorem
 
 wikidata: Q3527102
-msc_classification: "05"
+msc_classification: '05'
 wikipedia_links:
-  - "[[Kruskal–Katona theorem]]"
+- '[[Kruskal–Katona theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q3527102
+  authors:
+  - Bhavik Mehta, Yaël Dillies
+  date: 2020
+
 ---

--- a/_thm/Q3527118.md
+++ b/_thm/Q3527118.md
@@ -2,7 +2,12 @@
 # Mahler's theorem
 
 wikidata: Q3527118
-msc_classification: "11"
+msc_classification: '11'
 wikipedia_links:
-  - "[[Mahler's theorem]]"
+- '[[Mahler''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q3527118
+
 ---

--- a/_thm/Q3527189.md
+++ b/_thm/Q3527189.md
@@ -2,7 +2,12 @@
 # Lattice theorem
 
 wikidata: Q3527189
-msc_classification: "16"
+msc_classification: '16'
 wikipedia_links:
-  - "[[Lattice theorem]]"
+- '[[Lattice theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q3527189
+
 ---

--- a/_thm/Q3527205.md
+++ b/_thm/Q3527205.md
@@ -2,7 +2,12 @@
 # Dimension theorem for vector spaces
 
 wikidata: Q3527205
-msc_classification: "15"
+msc_classification: '15'
 wikipedia_links:
-  - "[[Dimension theorem for vector spaces]]"
+- '[[Dimension theorem for vector spaces]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q3527205
+
 ---

--- a/_thm/Q3527215.md
+++ b/_thm/Q3527215.md
@@ -2,7 +2,15 @@
 # Hilbert projection theorem
 
 wikidata: Q3527215
-msc_classification: "46"
+msc_classification: '46'
 wikipedia_links:
-  - "[[Hilbert projection theorem]]"
+- '[[Hilbert projection theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q3527215
+  authors:
+  - Zhouhang Zhou
+  date: 2019
+
 ---

--- a/_thm/Q3527250.md
+++ b/_thm/Q3527250.md
@@ -2,7 +2,15 @@
 # Hadamard three-lines theorem
 
 wikidata: Q3527250
-msc_classification: "30"
+msc_classification: '30'
 wikipedia_links:
-  - "[[Hadamard three-lines theorem]]"
+- '[[Hadamard three-lines theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q3527250
+  authors:
+  - Xavier Généreux
+  date: 2023
+
 ---

--- a/_thm/Q3527263.md
+++ b/_thm/Q3527263.md
@@ -2,7 +2,15 @@
 # Kleene fixed-point theorem
 
 wikidata: Q3527263
-msc_classification: "06"
+msc_classification: '06'
 wikipedia_links:
-  - "[[Kleene fixed-point theorem]]"
+- '[[Kleene fixed-point theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q3527263
+  authors:
+  - Ira Fesefeldt
+  date: 2024
+
 ---

--- a/_thm/Q3984053.md
+++ b/_thm/Q3984053.md
@@ -2,7 +2,15 @@
 # Fourier inversion theorem
 
 wikidata: Q3984053
-msc_classification: "43"
+msc_classification: '43'
 wikipedia_links:
-  - "[[Fourier inversion theorem]]"
+- '[[Fourier inversion theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q3984053
+  authors:
+  - Sébastien Gouëzel
+  date: 2024
+
 ---

--- a/_thm/Q420714.md
+++ b/_thm/Q420714.md
@@ -2,7 +2,12 @@
 # Akra–Bazzi theorem
 
 wikidata: Q420714
-msc_classification: "68"
+msc_classification: '68'
 wikipedia_links:
-  - "[[Akra–Bazzi theorem]]"
+- '[[Akra–Bazzi theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q420714
+
 ---

--- a/_thm/Q4378868.md
+++ b/_thm/Q4378868.md
@@ -2,7 +2,15 @@
 # Phragmén–Lindelöf theorem
 
 wikidata: Q4378868
-msc_classification: "30"
+msc_classification: '30'
 wikipedia_links:
-  - "[[Phragmén–Lindelöf theorem]]"
+- '[[Phragmén–Lindelöf theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q4378868
+  authors:
+  - Yury G. Kudryashov
+  date: 2022
+
 ---

--- a/_thm/Q459547.md
+++ b/_thm/Q459547.md
@@ -2,7 +2,14 @@
 # Ptolemy's theorem
 
 wikidata: Q459547
-msc_classification: "51"
+msc_classification: '51'
 wikipedia_links:
-  - "[[Ptolemy's theorem]]"
+- '[[Ptolemy''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q459547
+  authors:
+  - Manuel Candales
+
 ---

--- a/_thm/Q468391.md
+++ b/_thm/Q468391.md
@@ -2,7 +2,12 @@
 # Bolzano–Weierstrass theorem
 
 wikidata: Q468391
-msc_classification: "26"
+msc_classification: '26'
 wikipedia_links:
-  - "[[Bolzano–Weierstrass theorem]]"
+- '[[Bolzano–Weierstrass theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q468391
+
 ---

--- a/_thm/Q4695203.md
+++ b/_thm/Q4695203.md
@@ -2,7 +2,15 @@
 # Four functions theorem
 
 wikidata: Q4695203
-msc_classification: "05"
+msc_classification: '05'
 wikipedia_links:
-  - "[[Four functions theorem]]"
+- '[[Four functions theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q4695203
+  authors:
+  - Yaël Dillies
+  date: 2023
+
 ---

--- a/_thm/Q470877.md
+++ b/_thm/Q470877.md
@@ -2,7 +2,17 @@
 # Stirling's theorem
 
 wikidata: Q470877
-msc_classification: "26"
+msc_classification: '26'
 wikipedia_links:
-  - "[[Stirling's theorem]]"
+- '[[Stirling''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q470877
+  authors:
+  - Moritz Firsching
+  - Fabian Kruse
+  - Nikolas Kuhn
+  - Heather Macbeth
+
 ---

--- a/_thm/Q472883.md
+++ b/_thm/Q472883.md
@@ -2,7 +2,15 @@
 # Quadratic reciprocity theorem
 
 wikidata: Q472883
-msc_classification: "11"
+msc_classification: '11'
 wikipedia_links:
-  - "[[Quadratic reciprocity theorem]]"
+- '[[Quadratic reciprocity theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q472883
+  authors:
+  - Chris Hughes (first)
+  - Michael Stoll (second)
+
 ---

--- a/_thm/Q474881.md
+++ b/_thm/Q474881.md
@@ -2,7 +2,15 @@
 # Cantor's theorem
 
 wikidata: Q474881
-msc_classification: "03"
+msc_classification: '03'
 wikipedia_links:
-  - "[[Cantor's theorem]]"
+- '[[Cantor''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q474881
+  authors:
+  - Johannes Hölzl
+  - Mario Carneiro
+
 ---

--- a/_thm/Q476776.md
+++ b/_thm/Q476776.md
@@ -2,7 +2,14 @@
 # Solutions of a general quartic equation
 
 wikidata: Q476776
-msc_classification: "12"
+msc_classification: '12'
 wikipedia_links:
-  - "[[Quartic equation|Solutions of a general quartic equation]]"
+- '[[Quartic equation|Solutions of a general quartic equation]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q476776
+  authors:
+  - Thomas Zhu
+
 ---

--- a/_thm/Q4830725.md
+++ b/_thm/Q4830725.md
@@ -2,7 +2,15 @@
 # Ax–Grothendieck theorem
 
 wikidata: Q4830725
-msc_classification: "03"
+msc_classification: '03'
 wikipedia_links:
-  - "[[Ax–Grothendieck theorem]]"
+- '[[Ax–Grothendieck theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q4830725
+  authors:
+  - Chris Hughes
+  date: 2023
+
 ---

--- a/_thm/Q505798.md
+++ b/_thm/Q505798.md
@@ -2,7 +2,12 @@
 # Lagrange's theorem
 
 wikidata: Q505798
-msc_classification: "20"
+msc_classification: '20'
 wikipedia_links:
-  - "[[Lagrange's theorem (group theory)|Lagrange's theorem]]"
+- '[[Lagrange''s theorem (group theory)|Lagrange''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q505798
+
 ---

--- a/_thm/Q5171652.md
+++ b/_thm/Q5171652.md
@@ -2,7 +2,15 @@
 # Corners theorem
 
 wikidata: Q5171652
-msc_classification: "11"
+msc_classification: '11'
 wikipedia_links:
-  - "[[Corners theorem]]"
+- '[[Corners theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q5171652
+  authors:
+  - Yaël Dillies, Bhavik Mehta
+  date: 2022
+
 ---

--- a/_thm/Q530152.md
+++ b/_thm/Q530152.md
@@ -2,7 +2,12 @@
 # Picard&ndash;Lindelöf theorem
 
 wikidata: Q530152
-msc_classification: "34"
+msc_classification: '34'
 wikipedia_links:
-  - "[[Picard&ndash;Lindelöf theorem]]"
+- '[[Picard&ndash;Lindelöf theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q530152
+
 ---

--- a/_thm/Q536640.md
+++ b/_thm/Q536640.md
@@ -2,7 +2,12 @@
 # Hall's marriage theorem
 
 wikidata: Q536640
-msc_classification: "05"
+msc_classification: '05'
 wikipedia_links:
-  - "[[Hall's marriage theorem]]"
+- '[[Hall''s marriage theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q536640
+
 ---

--- a/_thm/Q537618.md
+++ b/_thm/Q537618.md
@@ -2,7 +2,12 @@
 # Banach–Alaoglu theorem
 
 wikidata: Q537618
-msc_classification: "46"
+msc_classification: '46'
 wikipedia_links:
-  - "[[Banach–Alaoglu theorem]]"
+- '[[Banach–Alaoglu theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q537618
+
 ---

--- a/_thm/Q5437947.md
+++ b/_thm/Q5437947.md
@@ -2,7 +2,12 @@
 # Fatou–Lebesgue theorem
 
 wikidata: Q5437947
-msc_classification: "26"
+msc_classification: '26'
 wikipedia_links:
-  - "[[Fatou–Lebesgue theorem]]"
+- '[[Fatou–Lebesgue theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q5437947
+
 ---

--- a/_thm/Q550402.md
+++ b/_thm/Q550402.md
@@ -2,7 +2,14 @@
 # Dirichlet's theorem on arithmetic progressions
 
 wikidata: Q550402
-msc_classification: "11"
+msc_classification: '11'
 wikipedia_links:
-  - "[[Dirichlet's theorem on arithmetic progressions]]"
+- '[[Dirichlet''s theorem on arithmetic progressions]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q550402
+  authors:
+  - David Loeffler, Michael Stoll
+
 ---

--- a/_thm/Q5504427.md
+++ b/_thm/Q5504427.md
@@ -2,7 +2,16 @@
 # Friendship theorem
 
 wikidata: Q5504427
-msc_classification: "05"
+msc_classification: '05'
 wikipedia_links:
-  - "[[Friendship theorem]]"
+- '[[Friendship theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q5504427
+  authors:
+  - Aaron Anderson
+  - Jalex Stark
+  - Kyle Miller
+
 ---

--- a/_thm/Q570779.md
+++ b/_thm/Q570779.md
@@ -2,7 +2,12 @@
 # Vieta's formulas
 
 wikidata: Q570779
-msc_classification: "13"
+msc_classification: '13'
 wikipedia_links:
-  - "[[Vieta's formulas]]"
+- '[[Vieta''s formulas]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q570779
+
 ---

--- a/_thm/Q576478.md
+++ b/_thm/Q576478.md
@@ -2,7 +2,12 @@
 # Liouville's theorem
 
 wikidata: Q576478
-msc_classification: "30"
+msc_classification: '30'
 wikipedia_links:
-  - "[[Liouville's theorem (complex analysis)|Liouville's theorem]]"
+- '[[Liouville''s theorem (complex analysis)|Liouville''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q576478
+
 ---

--- a/_thm/Q609612.md
+++ b/_thm/Q609612.md
@@ -2,7 +2,15 @@
 # Knaster–Tarski theorem
 
 wikidata: Q609612
-msc_classification: "06"
+msc_classification: '06'
 wikipedia_links:
-  - "[[Knaster–Tarski theorem]]"
+- '[[Knaster–Tarski theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q609612
+  authors:
+  - Kenny Lau
+  date: 2018
+
 ---

--- a/_thm/Q619985.md
+++ b/_thm/Q619985.md
@@ -2,7 +2,12 @@
 # Multinomial theorem
 
 wikidata: Q619985
-msc_classification: "05"
+msc_classification: '05'
 wikipedia_links:
-  - "[[Multinomial theorem]]"
+- '[[Multinomial theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q619985
+
 ---

--- a/_thm/Q632546.md
+++ b/_thm/Q632546.md
@@ -2,7 +2,15 @@
 # Bertrand's postulate
 
 wikidata: Q632546
-msc_classification: "11"
+msc_classification: '11'
 wikipedia_links:
-  - "[[Bertrand's postulate]]"
+- '[[Bertrand''s postulate]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q632546
+  authors:
+  - Bolton Bailey
+  - Patrick Stevens
+
 ---

--- a/_thm/Q642620.md
+++ b/_thm/Q642620.md
@@ -2,7 +2,15 @@
 # Krein–Milman theorem
 
 wikidata: Q642620
-msc_classification: "52"
+msc_classification: '52'
 wikipedia_links:
-  - "[[Krein–Milman theorem]]"
+- '[[Krein–Milman theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q642620
+  authors:
+  - Yaël Dillies
+  date: 2022
+
 ---

--- a/_thm/Q656772.md
+++ b/_thm/Q656772.md
@@ -2,7 +2,14 @@
 # Cayley–Hamilton theorem
 
 wikidata: Q656772
-msc_classification: "15"
+msc_classification: '15'
 wikipedia_links:
-  - "[[Cayley–Hamilton theorem]]"
+- '[[Cayley–Hamilton theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q656772
+  authors:
+  - Kim Morrison
+
 ---

--- a/_thm/Q657482.md
+++ b/_thm/Q657482.md
@@ -2,7 +2,14 @@
 # Abel–Ruffini theorem
 
 wikidata: Q657482
-msc_classification: "12"
+msc_classification: '12'
 wikipedia_links:
-  - "[[Abel–Ruffini theorem]]"
+- '[[Abel–Ruffini theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q657482
+  authors:
+  - Thomas Browning
+
 ---

--- a/_thm/Q670235.md
+++ b/_thm/Q670235.md
@@ -2,7 +2,17 @@
 # Fundamental theorem of arithmetic
 
 wikidata: Q670235
-msc_classification: "11"
+msc_classification: '11'
 wikipedia_links:
-  - "[[Fundamental theorem of arithmetic]]"
+- '[[Fundamental theorem of arithmetic]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q670235
+  authors:
+  - Chris Hughes
+  comment: it also has a generalized version, by showing that every Euclidean domain
+    is a unique factorization domain, and showing that the integers form a Euclidean
+    domain.
+
 ---

--- a/_thm/Q6757284.md
+++ b/_thm/Q6757284.md
@@ -2,7 +2,15 @@
 # Marcinkiewicz theorem
 
 wikidata: Q6757284
-msc_classification: "46"
+msc_classification: '46'
 wikipedia_links:
-  - "[[Marcinkiewicz theorem]]"
+- '[[Marcinkiewicz theorem]]'
+lean:
+- status: formalized
+  library: X
+  url: https://leanprover-community.github.io/1000.html#Q6757284
+  authors:
+  - Jim Portegies
+  date: 2024-09-06
+
 ---

--- a/_thm/Q6813106.md
+++ b/_thm/Q6813106.md
@@ -2,7 +2,12 @@
 # Mellin inversion theorem
 
 wikidata: Q6813106
-msc_classification: "30"
+msc_classification: '30'
 wikipedia_links:
-  - "[[Mellin inversion theorem]]"
+- '[[Mellin inversion theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q6813106
+
 ---

--- a/_thm/Q716171.md
+++ b/_thm/Q716171.md
@@ -2,7 +2,15 @@
 # Erdős–Ginzburg–Ziv theorem
 
 wikidata: Q716171
-msc_classification: "11"
+msc_classification: '11'
 wikipedia_links:
-  - "[[Erdős–Ginzburg–Ziv theorem]]"
+- '[[Erdős–Ginzburg–Ziv theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q716171
+  authors:
+  - Yaël Dillies
+  date: 2023
+
 ---

--- a/_thm/Q718875.md
+++ b/_thm/Q718875.md
@@ -2,7 +2,15 @@
 # Erdős–Ko–Rado theorem
 
 wikidata: Q718875
-msc_classification: "05"
+msc_classification: '05'
 wikipedia_links:
-  - "[[Erdős–Ko–Rado theorem]]"
+- '[[Erdős–Ko–Rado theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q718875
+  authors:
+  - Bhavik Mehta, Yaël Dillies
+  date: 2020
+
 ---

--- a/_thm/Q720469.md
+++ b/_thm/Q720469.md
@@ -2,7 +2,15 @@
 # Chevalley–Warning theorem
 
 wikidata: Q720469
-msc_classification: "12"
+msc_classification: '12'
 wikipedia_links:
-  - "[[Chevalley–Warning theorem]]"
+- '[[Chevalley–Warning theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q720469
+  authors:
+  - Johan Commelin
+  date: 2019
+
 ---

--- a/_thm/Q7309601.md
+++ b/_thm/Q7309601.md
@@ -2,7 +2,14 @@
 # Whitney–Graustein Theorem
 
 wikidata: Q7309601
-msc_classification: "55"
+msc_classification: '55'
 wikipedia_links:
-  - "[[Regular homotopy|Whitney–Graustein Theorem]]"
+- '[[Regular homotopy|Whitney–Graustein Theorem]]'
+lean:
+- status: formalized
+  library: X
+  url: https://leanprover-community.github.io/1000.html#Q7309601
+  comment: assumes some basic topology statements as axioms; use the sphere eversion
+    project
+
 ---

--- a/_thm/Q7432915.md
+++ b/_thm/Q7432915.md
@@ -2,7 +2,12 @@
 # Schroeder–Bernstein theorem for measurable spaces
 
 wikidata: Q7432915
-msc_classification: "28"
+msc_classification: '28'
 wikipedia_links:
-  - "[[Schroeder–Bernstein theorem for measurable spaces]]"
+- '[[Schroeder–Bernstein theorem for measurable spaces]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q7432915
+
 ---

--- a/_thm/Q7433182.md
+++ b/_thm/Q7433182.md
@@ -2,7 +2,15 @@
 # Schwartz–Zippel theorem
 
 wikidata: Q7433182
-msc_classification: "12"
+msc_classification: '12'
 wikipedia_links:
-  - "[[Schwartz–Zippel theorem]]"
+- '[[Schwartz–Zippel theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q7433182
+  authors:
+  - Bolton Bailey, Yaël Dillies
+  date: 2023
+
 ---

--- a/_thm/Q748233.md
+++ b/_thm/Q748233.md
@@ -2,7 +2,15 @@
 # Sylvester–Gallai theorem
 
 wikidata: Q748233
-msc_classification: "51"
+msc_classification: '51'
 wikipedia_links:
-  - "[[Sylvester–Gallai theorem]]"
+- '[[Sylvester–Gallai theorem]]'
+lean:
+- status: formalized
+  library: X
+  url: https://leanprover-community.github.io/1000.html#Q748233
+  authors:
+  - Bhavik Mehta
+  date: 2022
+
 ---

--- a/_thm/Q752375.md
+++ b/_thm/Q752375.md
@@ -2,7 +2,15 @@
 # Extreme value theorem
 
 wikidata: Q752375
-msc_classification: "26"
+msc_classification: '26'
 wikipedia_links:
-  - "[[Extreme value theorem]]"
+- '[[Extreme value theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q752375
+  authors:
+  - Sébastien Gouëzel
+  date: 2018
+
 ---

--- a/_thm/Q756946.md
+++ b/_thm/Q756946.md
@@ -2,7 +2,15 @@
 # Lagrange's four-square theorem
 
 wikidata: Q756946
-msc_classification: "11"
+msc_classification: '11'
 wikipedia_links:
-  - "[[Lagrange's four-square theorem]]"
+- '[[Lagrange''s four-square theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q756946
+  authors:
+  - Chris Hughes
+  date: 2019
+
 ---

--- a/_thm/Q764287.md
+++ b/_thm/Q764287.md
@@ -2,7 +2,14 @@
 # Van der Waerden's theorem
 
 wikidata: Q764287
-msc_classification: "05"
+msc_classification: '05'
 wikipedia_links:
-  - "[[Van der Waerden's theorem]]"
+- '[[Van der Waerden''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q764287
+  authors:
+  - David Wärn
+
 ---

--- a/_thm/Q765987.md
+++ b/_thm/Q765987.md
@@ -2,7 +2,12 @@
 # Heine–Cantor theorem
 
 wikidata: Q765987
-msc_classification: "51"
+msc_classification: '51'
 wikipedia_links:
-  - "[[Heine–Cantor theorem]]"
+- '[[Heine–Cantor theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q765987
+
 ---

--- a/_thm/Q776578.md
+++ b/_thm/Q776578.md
@@ -2,8 +2,13 @@
 # Artin–Wedderburn theorem
 
 wikidata: Q776578
-msc_classification: "16"
+msc_classification: '16'
 wikipedia_links:
-  - "[[Artin–Wedderburn theorem]]"
-  - "[[Artin–Wedderburn theorem|Wedderburn's theorem]]"
+- '[[Artin–Wedderburn theorem]]'
+- '[[Artin–Wedderburn theorem|Wedderburn''s theorem]]'
+lean:
+- status: statement
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q776578
+
 ---

--- a/_thm/Q7820874.md
+++ b/_thm/Q7820874.md
@@ -2,7 +2,12 @@
 # Tonelli's theorem
 
 wikidata: Q7820874
-msc_classification: "46"
+msc_classification: '46'
 wikipedia_links:
-  - "[[Tonelli's theorem (functional analysis)|Tonelli's theorem]]"
+- '[[Tonelli''s theorem (functional analysis)|Tonelli''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q7820874
+
 ---

--- a/_thm/Q7888360.md
+++ b/_thm/Q7888360.md
@@ -2,7 +2,15 @@
 # Structure theorem for finitely generated modules over a principal ideal domain
 
 wikidata: Q7888360
-msc_classification: "16"
+msc_classification: '16'
 wikipedia_links:
-  - "[[Structure theorem for finitely generated modules over a principal ideal domain]]"
+- '[[Structure theorem for finitely generated modules over a principal ideal domain]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q7888360
+  authors:
+  - Pierre-Alexandre Bazin
+  date: 2022
+
 ---

--- a/_thm/Q834025.md
+++ b/_thm/Q834025.md
@@ -2,7 +2,15 @@
 # Cauchy integral theorem
 
 wikidata: Q834025
-msc_classification: "30"
+msc_classification: '30'
 wikipedia_links:
-  - "[[Cauchy integral theorem]]"
+- '[[Cauchy integral theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q834025
+  authors:
+  - Yury Kudryashov
+  date: 2021
+
 ---

--- a/_thm/Q837506.md
+++ b/_thm/Q837506.md
@@ -2,7 +2,15 @@
 # Theorem on friends and strangers
 
 wikidata: Q837506
-msc_classification: "05"
+msc_classification: '05'
 wikipedia_links:
-  - "[[Theorem on friends and strangers]]"
+- '[[Theorem on friends and strangers]]'
+lean:
+- status: formalized
+  library: X
+  url: https://leanprover-community.github.io/1000.html#Q837506
+  authors:
+  - Bhavik Mehta
+  comment: will enter mathlib in 2024
+
 ---

--- a/_thm/Q842953.md
+++ b/_thm/Q842953.md
@@ -2,7 +2,15 @@
 # Lebesgue's density theorem
 
 wikidata: Q842953
-msc_classification: "54"
+msc_classification: '54'
 wikipedia_links:
-  - "[[Lebesgue's density theorem]]"
+- '[[Lebesgue''s density theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q842953
+  authors:
+  - Oliver Nash
+  date: 2022
+
 ---

--- a/_thm/Q848375.md
+++ b/_thm/Q848375.md
@@ -2,7 +2,12 @@
 # Implicit function theorem
 
 wikidata: Q848375
-msc_classification: "26"
+msc_classification: '26'
 wikipedia_links:
-  - "[[Implicit function theorem]]"
+- '[[Implicit function theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q848375
+
 ---

--- a/_thm/Q853067.md
+++ b/_thm/Q853067.md
@@ -2,7 +2,16 @@
 # Solutions to Pell's equation
 
 wikidata: Q853067
-msc_classification: "11"
+msc_classification: '11'
 wikipedia_links:
-  - "[[Pell's equation|Solutions to Pell's equation]]"
+- '[[Pell''s equation|Solutions to Pell''s equation]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q853067
+  authors:
+  - Mario Carneiro (first), Michael Stoll (second)
+  comment: In `pell.eq_pell`, `d` is defined to be `a*a - 1` for an arbitrary `a >
+    1`.
+
 ---

--- a/_thm/Q866116.md
+++ b/_thm/Q866116.md
@@ -2,7 +2,12 @@
 # Hahn–Banach theorem
 
 wikidata: Q866116
-msc_classification: "46"
+msc_classification: '46'
 wikipedia_links:
-  - "[[Hahn–Banach theorem]]"
+- '[[Hahn–Banach theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q866116
+
 ---

--- a/_thm/Q914517.md
+++ b/_thm/Q914517.md
@@ -2,7 +2,14 @@
 # Fermat's theorem on sums of two squares
 
 wikidata: Q914517
-msc_classification: "11"
+msc_classification: '11'
 wikipedia_links:
-  - "[[Fermat's theorem on sums of two squares]]"
+- '[[Fermat''s theorem on sums of two squares]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q914517
+  authors:
+  - Chris Hughes
+
 ---

--- a/_thm/Q918099.md
+++ b/_thm/Q918099.md
@@ -2,7 +2,14 @@
 # Ramsey's theorem
 
 wikidata: Q918099
-msc_classification: "05"
+msc_classification: '05'
 wikipedia_links:
-  - "[[Ramsey's theorem]]"
+- '[[Ramsey''s theorem]]'
+lean:
+- status: formalized
+  library: X
+  url: https://leanprover-community.github.io/1000.html#Q918099
+  authors:
+  - Bhavik Mehta
+
 ---

--- a/_thm/Q931001.md
+++ b/_thm/Q931001.md
@@ -2,7 +2,12 @@
 # Inverse function theorem
 
 wikidata: Q931001
-msc_classification: "26"
+msc_classification: '26'
 wikipedia_links:
-  - "[[Inverse function theorem]]"
+- '[[Inverse function theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q931001
+
 ---

--- a/_thm/Q939927.md
+++ b/_thm/Q939927.md
@@ -2,14 +2,16 @@
 # Stone–Weierstrass theorem
 
 wikidata: Q939927
-msc_classification: "46"
+msc_classification: '46'
 wikipedia_links:
-  - "[[Stone–Weierstrass theorem]]"
-
+- '[[Stone–Weierstrass theorem]]'
 lean:
-  - status: formalized
-    library: L
-    url: "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Topology/ContinuousMap/StoneWeierstrass.html#ContinuousMap.subalgebra_topologicalClosure_eq_top_of_separatesPoints"
-    authors: [Scott Morrison, Heather Macbeth]
-    date: 2021-05-01
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q939927
+  authors:
+  - Scott Morrison
+  - Heather Macbeth
+  date: 2021-05-01
+
 ---

--- a/_thm/Q943246.md
+++ b/_thm/Q943246.md
@@ -2,7 +2,12 @@
 # Wedderburn's little theorem
 
 wikidata: Q943246
-msc_classification: "13"
+msc_classification: '13'
 wikipedia_links:
-  - "[[Wedderburn's little theorem]]"
+- '[[Wedderburn''s little theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q943246
+
 ---

--- a/_thm/Q948664.md
+++ b/_thm/Q948664.md
@@ -2,7 +2,15 @@
 # Kneser's theorem
 
 wikidata: Q948664
-msc_classification: "05"
+msc_classification: '05'
 wikipedia_links:
-  - "[[Kneser's theorem (combinatorics)|Kneser's theorem]]"
+- '[[Kneser''s theorem (combinatorics)|Kneser''s theorem]]'
+lean:
+- status: formalized
+  library: X
+  url: https://leanprover-community.github.io/1000.html#Q948664
+  authors:
+  - Mantas Bakšys, Yaël Dillies
+  date: 2022
+
 ---

--- a/_thm/Q967972.md
+++ b/_thm/Q967972.md
@@ -2,7 +2,12 @@
 # Open mapping theorem
 
 wikidata: Q967972
-msc_classification: "30"
+msc_classification: '30'
 wikipedia_links:
-  - "[[Open mapping theorem (complex analysis)|Open mapping theorem]]"
+- '[[Open mapping theorem (complex analysis)|Open mapping theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q967972
+
 ---

--- a/_thm/Q976607.md
+++ b/_thm/Q976607.md
@@ -2,7 +2,14 @@
 # Erdős–Szekeres theorem
 
 wikidata: Q976607
-msc_classification: "52"
+msc_classification: '52'
 wikipedia_links:
-  - "[[Erdős–Szekeres theorem]]"
+- '[[Erdős–Szekeres theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q976607
+  authors:
+  - Bhavik Mehta
+
 ---

--- a/_thm/Q9993851.md
+++ b/_thm/Q9993851.md
@@ -2,7 +2,12 @@
 # Lax–Milgram theorem
 
 wikidata: Q9993851
-msc_classification: "35"
+msc_classification: '35'
 wikipedia_links:
-  - "[[Lax–Milgram theorem]]"
+- '[[Lax–Milgram theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q9993851
+
 ---


### PR DESCRIPTION
This is automatically generated from a .yaml file in mathlib. A script to generate this commit will be added in a future pull request.

I am not particularly fond of the new yaml file formatting. When the script is PRed, I'll gladly take tweaks to the script which preserve the old formatting.