### PR TITLE
feat: add script for bi-directional synchronisation of the Lean formalisation data

### DIFF
--- a/_thm/Q1457052.md
+++ b/_thm/Q1457052.md
@@ -2,7 +2,15 @@
 # Well-ordering theorem
 
 wikidata: Q1457052
-msc_classification: "03"
+msc_classification: '03'
 wikipedia_links:
-  - "[[Well-ordering theorem]]"
+- '[[Well-ordering theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1457052
+  authors:
+  - Mario Carneiro, Chris Hughes, Violeta Hernández
+  date: 2017
+
 ---

--- a/_thm/Q1766814.md
+++ b/_thm/Q1766814.md
@@ -2,7 +2,17 @@
 # Smn theorem
 
 wikidata: Q1766814
-msc_classification: "68"
+msc_classification: '68'
 wikipedia_links:
-  - "[[Smn theorem]]"
+- '[[Smn theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1766814
+  authors:
+  - Mario Carneiro
+  date: 2018
+  comment: This theorem is trivial when using Mathlib's computability definition,
+    but this definition is equivalent to the usual one, as shown in `Nat.Partrec'.part_iff`.
+
 ---

--- a/_thm/Q1933521.md
+++ b/_thm/Q1933521.md
@@ -2,7 +2,15 @@
 # Kleene's recursion theorem
 
 wikidata: Q1933521
-msc_classification: "03"
+msc_classification: '03'
 wikipedia_links:
-  - "[[Kleene's recursion theorem]]"
+- '[[Kleene''s recursion theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1933521
+  authors:
+  - Mario Carneiro
+  date: 2018
+
 ---

--- a/_thm/Q422187.md
+++ b/_thm/Q422187.md
@@ -2,7 +2,15 @@
 # Myhill–Nerode theorem
 
 wikidata: Q422187
-msc_classification: "68"
+msc_classification: '68'
 wikipedia_links:
-  - "[[Myhill–Nerode theorem]]"
+- '[[Myhill–Nerode theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q422187
+  authors:
+  - Chris Wong
+  date: 2024-03-24
+
 ---

--- a/_thm/Q4878586.md
+++ b/_thm/Q4878586.md
@@ -2,7 +2,15 @@
 # Beck's monadicity theorem
 
 wikidata: Q4878586
-msc_classification: "18"
+msc_classification: '18'
 wikipedia_links:
-  - "[[Beck's monadicity theorem]]"
+- '[[Beck''s monadicity theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q4878586
+  authors:
+  - Bhavik Mehta
+  date: 2020
+
 ---

--- a/_thm/Q595466.md
+++ b/_thm/Q595466.md
@@ -2,7 +2,15 @@
 # Dini's theorem
 
 wikidata: Q595466
-msc_classification: "26"
+msc_classification: '26'
 wikipedia_links:
-  - "[[Dini's theorem]]"
+- '[[Dini''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q595466
+  authors:
+  - Jireh Loreaux
+  date: 2024
+
 ---

--- a/_thm/Q656645.md
+++ b/_thm/Q656645.md
@@ -2,7 +2,15 @@
 # Hilbert's basis theorem
 
 wikidata: Q656645
-msc_classification: "13"
+msc_classification: '13'
 wikipedia_links:
-  - "[[Hilbert's basis theorem]]"
+- '[[Hilbert''s basis theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q656645
+  authors:
+  - Kenny Lau
+  date: 2019
+
 ---

--- a/_thm/Q810431.md
+++ b/_thm/Q810431.md
@@ -2,7 +2,15 @@
 # Basel problem
 
 wikidata: Q810431
-msc_classification: "26"
+msc_classification: '26'
 wikipedia_links:
-  - "[[Basel problem]]"
+- '[[Basel problem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q810431
+  authors:
+  - David Loeffler
+  date: 2022
+
 ---

--- a/_thm/Q944297.md
+++ b/_thm/Q944297.md
@@ -1,8 +1,16 @@
 ---
-# Open mapping theorem
+# Open mapping theorem (functional analysis)
 
 wikidata: Q944297
-msc_classification: "46"
+msc_classification: '46'
 wikipedia_links:
-  - "[[Open mapping theorem (functional analysis)|Open mapping theorem]]"
+- '[[Open mapping theorem (functional analysis)|Open mapping theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q944297
+  authors:
+  - Sébastien Gouëzel
+  date: 2019
+
 ---

--- a/sync_mathlib_data.py
+++ b/sync_mathlib_data.py
@@ -1,0 +1,294 @@
+"""
+This script contains tools for bi-directional synchronisation
+of the Lean formalisation data with this repository's.
+
+The "downward" direction takes the data from a local checkout of this script
+and generates a file 1000.yaml containing all relevant information about Lean
+formalisations: that file is used in Lean's mathlib library.
+
+The "upward" direction reads the file 1000.yaml from mathlib
+(passed in as a local file), compares the data about Lean formalisations
+with the one in this repository and adds/overwrites this (and only this) data.
+
+This script depends on the details of the file 1000.yaml in mathlib,
+so should evolve with any changes there.
+"""
+
+
+import os
+from enum import Enum, auto
+from typing import List, NamedTuple
+from datetime import datetime
+import yaml
+
+class ProofAssistant(Enum):
+    Isabelle = auto()
+    HolLight = auto()
+    Coq = auto()
+    Lean = auto()
+    Metamath = auto()
+    Mizar = auto()
+
+
+# The different formalisation statusses: just the statement or also the proof.
+class FormalizationStatus(Enum):
+    # The statement of a result was formalized (but not its proof yet).
+    Statement = auto()
+    # The full proof of a result was formalized.
+    FullProof = auto()
+
+
+# In what library does the formalization appear?
+class Library(Enum):
+    # The standard library ("S")
+    StandardLibrary = auto()
+    # The main/biggest mathematical library ("L").
+    # (afp, hol light outside standard library, mathcomp, mathlib, mml, set.mm, respectively.)
+    MainLibrary = auto()
+    # External to the main or standard library (e.g., a dedicated repository) ("X")
+    External = auto()
+
+
+class FormalisationEntry(NamedTuple):
+    status: FormalizationStatus
+    library: Library
+    # A URL pointing to the formalization
+    url: str
+    # A list of theorems for a particular proof assistant: can we make this required instead?
+    # Perhaps make the URL optional for 'S' or 'M' formalisations? Need to discuss!
+    # Actually, I think requiring it is a better decision.
+    identifiers: str
+    authors: str | None
+    # Format YYYY-MM-DD in the source file.
+    date: datetime | None
+    comment: str | None
+
+
+# Information about a theorem entry: taken from the specification at
+# https://github.com/1000-plus/1000-plus.github.io/blob/main/README.md#file-format.
+class TheoremEntry(NamedTuple):
+    # Wikidata identifier for this theorem (or concept related to the theorem).
+    # Valid identifiers start with the latter Q followed by a number; we only save this number.
+    wikidata: int
+    # disambiguates an entry when two theorems have the same wikidata identifier.
+    # X means an extra theorem on a Wikipedia page (e.g. a generalization or special case),
+    # A/B/... means different theorems on one Wikipedia page that doesn't have a "main" theorem.
+    id_suffix: str | None
+    # Our best guess of the MSC-classification. (Should be a two-digit string; not validated.)
+    msc_classification: str
+    # The exact link to a wikipedia page: format [[Page name]] or [[Wiki-link|Displayed name]].
+    wikipedia_links: List[str]
+    # Entries about formalizations in any of the supported proof assistants.
+    # Several formalization entries for assistant are allowed.
+    formalisations: dict[ProofAssistant, List[FormalisationEntry]]
+
+
+def _parse_formalization_entry(entry: dict) -> FormalisationEntry:
+    form = {
+        "formalized": FormalizationStatus.FullProof,
+        "statement": FormalizationStatus.Statement,
+    }
+    status = form[entry["status"]]
+    lib = {
+        "S": Library.StandardLibrary,
+        "L": Library.MainLibrary,
+        "X": Library.External,
+    }
+    library = lib[entry["library"]]
+    identifiers = entry.get("identifiers")
+    if library == Library.External and identifiers is None:
+        print("invalid data: external formalisations should add precise identifiers!", file=sys.stderr)
+    return FormalisationEntry(
+        status, library, entry["url"], identifiers,
+        entry.get("authors"), entry.get("date"), entry.get("comment")
+    )
+
+
+def _parse_wikidata(input: str) -> int | None:
+    if not input.startswith("Q"):
+        print(f"error: invalid wikidata identifier {input}; must start with a letter 'Q'")
+        return None
+    try:
+        return int(input.removeprefix("Q"))
+    except ValueError:
+        print("invalid input: {input} must be the letter 'Q', followed by a number")
+        return None
+
+
+# Return a human-ready theorem title, as well as a `TheoremEntry` with the underlying data.
+# Return `None` if `contents` does not describe a valid theorem entry.
+def _parse_theorem_entry(contents: List[str]) -> TheoremEntry | None:
+    assert contents[0].rstrip() == "---"
+    assert contents[-1].rstrip() == "---"
+    # For optics, we check that all entry files start with the theorem name as comment.
+    # We parse the actual title from the wikipedia data below: this yields virtually the same results.
+    assert contents[1].startswith("# ") or contents[1].startswith("## ")
+    data = yaml.safe_load("".join(contents[1:-1]))
+    wikidata = _parse_wikidata(data["wikidata"])
+    if wikidata is None:
+        return None
+    provers: dict[str, ProofAssistant] = {
+        "isabelle": ProofAssistant.Isabelle,
+        "hol_light": ProofAssistant.HolLight,
+        "coq": ProofAssistant.Coq,
+        "lean": ProofAssistant.Lean,
+        "metamath": ProofAssistant.Metamath,
+        "mizar": ProofAssistant.Mizar,
+    }
+    formalisations = dict()
+    for pname, variant in provers.items():
+        if pname in data:
+            entries = [_parse_formalization_entry(entry) for entry in data[pname]]
+            formalisations[variant] = entries
+        else:
+            formalisations[variant] = []
+
+    res = TheoremEntry(
+        wikidata, data.get("id_suffix"), data["msc_classification"],
+        data["wikipedia_links"], formalisations
+    )
+    return res
+
+
+def _parse_title_inner(wiki_links: List[str]) -> str:
+    # FIXME: what's the best way to deal with multiple links here?
+    # For now, let's match the webpage and just show the first link's target.
+    # if len(entry.wikipedia_links) > 1:
+    #     print(f"attention: found several wikipedia links for a theorem: {entry.wikipedia_links}")
+    # Handle wikipedia links [[Big theorem]]s also.
+    (title, _, suf) = wiki_links[0].removeprefix("[[").partition("]]")
+    if suf == "s":
+        title += "s"
+    if "|" in title:
+        title = title.partition("|")[2]
+    return title
+
+def _parse_title(entry: TheoremEntry) -> str:
+    return _parse_title_inner(entry.wikipedia_links)
+
+
+def _write_entry(entry: TheoremEntry) -> str:
+    inner = {"title": _parse_title(entry)}
+    form = entry.formalisations[ProofAssistant.Lean]
+    if form:
+        # If there are several formalisations, we prioritise mathlib and stdlib
+        # formalisations over external projects.
+        # If there are still several, we pick the first in the theorem file.
+        stdlib_formalisations = [f for f in form if f.library == Library.StandardLibrary]
+        mathlib_formalisations = [f for f in form if f.library == Library.MainLibrary]
+        if stdlib_formalisations:
+            first = stdlib_formalisations[0]
+            if first.identifiers is not None:
+                if len(first.identifiers) == 1:
+                    inner["decl"] = first.identifiers[0]
+                else:
+                    inner["decls"] = first.identifiers
+        elif mathlib_formalisations:
+            first = mathlib_formalisations[0]
+            if first.identifiers is not None:
+                if len(first.identifiers) == 1:
+                    inner["decl"] = first.identifiers[0]
+                else:
+                    inner["decls"] = first.identifiers
+        else:
+            first = form[0]
+            assert first.library == Library.External  # internal consistency check
+            inner["url"] = first.url
+            # We conciously write out the identifiers of the external theorems,
+            # so they can be added upstream. Since we use a different key from the 'main library'
+            # case, tooling can distinguish these just fine.
+            inner["identifiers"] = first.identifiers
+        if first.authors:
+            # XXX: this is inconsistent with 100.yaml
+            # the former uses 'author' always; the 1000+ theorems project always uses 'authors'
+            inner["author"] = " and ".join(first.authors)
+        # Add additional metadata, so no information is lost in the generated yaml file.
+        if first.date:
+            inner['date'] = first.date
+        if first.comment:
+            inner['comment'] = first.comment
+    key = f"Q{entry.wikidata}" + (entry.id_suffix or "")
+    res = {key: inner}
+    return yaml.dump(res, sort_keys=False, allow_unicode=True)
+
+
+def regenerate_from_upstream(_args) -> None:
+    # FIXME: download the upstream files to a local directory; or
+    # if the --local option and a location are passed, look in that location instead.
+    # For now, the latter is used, with a hard-coded directory...
+    dir = "../1000-plus.github.io/_thm"
+    # Determine the list of theorem entry files.
+    theorem_entry_files = []
+    with os.scandir(dir) as entries:
+        theorem_entry_files = [entry.name for entry in entries if entry.is_file()]
+    # Parse each entry file into a theorem entry.
+    thms: List[TheoremEntry | None] = []
+    for file in theorem_entry_files:
+        with open(os.path.join(dir, file), "r") as f:
+            thms.append(_parse_theorem_entry(f.readlines()))
+    # Sort alphabetically according to wikidata ID.
+    # FUTURE: also use MSC classification?
+    filtered: List[TheoremEntry] = filter(lambda t: t is not None, thms)
+
+    # Write out a new yaml file for this, again.
+    with open(os.path.join("docs", "1000.yaml"), "w") as f:
+        f.write("\n".join([_write_entry(thm) for thm in sorted(filtered, key=lambda t: t.wikidata)]))
+
+
+def regenerate_upstream_from_yaml(dest_dir: str) -> None:
+    with open(os.path.join("docs", "1000.yaml"), "r") as f:
+        data_1000_yaml = yaml.safe_load(f)
+    for id_with_suffix, entry in data_1000_yaml.items():
+        has_formalisation = "decl" in entry or "decls" in entry or "identifiers" in entry
+        # For each downstream declaration, read in the "upstream" yaml file and compare with the
+        # downstream result.
+        with open(os.path.join(dest_dir, f"{id_with_suffix}.md"), 'r') as f:
+            contents = f.readlines()
+            upstream_data = yaml.safe_load("".join(contents[1:-1]))
+            upstream_lean_entry = _parse_theorem_entry(contents)
+        original_lean = []
+        if upstream_lean_entry:
+            original_lean = upstream_lean_entry.formalisations[ProofAssistant.Lean]
+
+        if original_lean and not has_formalisation:
+            print(f"update: Lean formalisation of {id_with_suffix} is noted upstream, but not downstream!")
+        elif original_lean and has_formalisation:
+            # FUTURE: compare the formalisation entries; not done right now
+            pass
+        elif has_formalisation and not original_lean:
+            print(f"update: found a new formalisation of {id_with_suffix} in 1000.yaml, "
+              "trying to update upstream file now")
+            # Augment the original file with information about the Lean formalisation.
+            decl = [entry.get("decl")] or entry.get("decls")
+            inner = {"status": "formalized"}
+            if decl:
+                # XXX: we assume no items came from the standard library...
+                inner["library"] = "M"
+                # We link an URL that "auto-fixes" itself: have doc-gen search for the declaration.
+                # As we know it exists, that will work fine :-)
+                inner["identifiers"] = decl
+                decl = f"https://leanprover-community.github.io/mathlib4_docs/find/?pattern={decl[0]}#doc"
+            else:
+                inner["library"] = "X"
+                inner["url"] = entry["url"]
+                inner["identifiers"] = entry["identifiers"]
+            if "author" in entry:
+                inner["authors"] = entry["author"].split(" and ")
+            if "date" in entry:
+                inner["date"] = entry["date"]
+            upstream_data["lean"] = [inner]
+            # Human-readable theorem title from the upstream file.
+            # We're not preserving (for now) if this was a section or sub-section.
+            # XXX: the generated formatting is not exactly the same, because yaml.dump...
+            # `ruamel` seems to be better here... for now, we decide to not care
+            title = _parse_title_inner(upstream_data["wikipedia_links"])
+            with open(os.path.join(dest_dir, f"{id_with_suffix}.md"), 'w') as f:
+                yamls = yaml.dump(upstream_data, indent=2, sort_keys=False)
+                f.write(f"---\n# {title}\n\n{yamls}\n---")
+
+
+if __name__ == "__main__":
+    import sys
+
+    regenerate_from_upstream(sys.argv)
+    # regenerate_upstream_from_yaml("../1000-plus.github.io/_thm")

--- a/sync_mathlib_data.py
+++ b/sync_mathlib_data.py
@@ -17,7 +17,7 @@ so should evolve with any changes there.
 
 import os
 from enum import Enum, auto
-from typing import List, NamedTuple
+from typing import List, NamedTuple, Optional
 from datetime import datetime
 import yaml
 
@@ -54,14 +54,10 @@ class FormalisationEntry(NamedTuple):
     library: Library
     # A URL pointing to the formalization
     url: str
-    # A list of theorems for a particular proof assistant: can we make this required instead?
-    # Perhaps make the URL optional for 'S' or 'M' formalisations? Need to discuss!
-    # Actually, I think requiring it is a better decision.
-    identifiers: str
-    authors: str | None
-    # Format YYYY-MM-DD in the source file.
-    date: datetime | None
-    comment: str | None
+    authors: Optional[str]
+    # Format `YYYY-MM-DD`, `YYYY-MM` or `YYYY` in the source file.
+    date: Optional[datetime]
+    comment: Optional[str]
 
 
 # Information about a theorem entry: taken from the specification at
@@ -73,13 +69,13 @@ class TheoremEntry(NamedTuple):
     # disambiguates an entry when two theorems have the same wikidata identifier.
     # X means an extra theorem on a Wikipedia page (e.g. a generalization or special case),
     # A/B/... means different theorems on one Wikipedia page that doesn't have a "main" theorem.
-    id_suffix: str | None
+    id_suffix: Optional[str]
     # Our best guess of the MSC-classification. (Should be a two-digit string; not validated.)
     msc_classification: str
     # The exact link to a wikipedia page: format [[Page name]] or [[Wiki-link|Displayed name]].
     wikipedia_links: List[str]
     # Entries about formalizations in any of the supported proof assistants.
-    # Several formalization entries for assistant are allowed.
+    # Several formalization entries for one assistant are allowed.
     formalisations: dict[ProofAssistant, List[FormalisationEntry]]
 
 

--- a/sync_mathlib_data.py
+++ b/sync_mathlib_data.py
@@ -12,6 +12,12 @@ with the one in this repository and adds/overwrites this (and only this) data.
 
 This script depends on the details of the file 1000.yaml in mathlib,
 so should evolve with any changes there.
+
+Usage: run
+  python3 sync_mathlib_data.py --downstream
+to regenerate a 1000-theorems-data.yaml file, and
+  python3 sync_mathlib_data.py --upstream <input_file.yaml>
+to update the contents of this repository from the file input_file.yaml.
 """
 
 
@@ -328,6 +334,18 @@ def regenerate_upstream_from_yaml(dest_dir: str) -> None:
 
 if __name__ == "__main__":
     import sys
-
-    regenerate_from_upstream()
-    # regenerate_upstream_from_yaml("../1000-plus.github.io/_thm")
+    match sys.argv.get(1):
+        case "--downstream":
+            regenerate_from_upstream()
+        case "--upstream":
+            input_file = sys.argv.get(2)
+            if input_file is None:
+                print("error: please specify the input file to read from: "
+                    "usage: python3 sync_mathlib_data.py --upstream <filename.yaml>", file=sys.stderr)
+                sys.exit(1)
+            pass  # regenerate_upstream_from_yaml("../1000-plus.github.io/_thm")
+        case _:
+            print("Please specify what you want to do: pass the --downstream option to regenerate a file 1000.yaml, "
+                "pass --upstream <filename.yaml> to update the theorem data files in this repository "
+                "from a downstream .yaml file.", file=sys.stderr)
+            sys.exit(1)

--- a/sync_mathlib_data.py
+++ b/sync_mathlib_data.py
@@ -97,11 +97,8 @@ class TheoremEntry(NamedTuple):
 def _parse_formalization_entry(entry: dict) -> FormalisationEntry:
     status = FormalizationStatus.from_str(entry["status"])
     library = Library.from_str(entry["library"])
-    identifiers = entry.get("identifiers")
-    if library == Library.External and identifiers is None:
-        print("invalid data: external formalisations should add precise identifiers!", file=sys.stderr)
     return FormalisationEntry(
-        status, library, entry["url"], identifiers,
+        status, library, entry["url"],
         entry.get("authors"), entry.get("date"), entry.get("comment")
     )
 
@@ -180,26 +177,26 @@ def _write_entry(entry: TheoremEntry) -> str:
         mathlib_formalisations = [f for f in form if f.library == Library.MainLibrary]
         if stdlib_formalisations:
             first = stdlib_formalisations[0]
-            if first.identifiers is not None:
-                if len(first.identifiers) == 1:
-                    inner["decl"] = first.identifiers[0]
-                else:
-                    inner["decls"] = first.identifiers
+            # if first.identifiers is not None:
+            #     if len(first.identifiers) == 1:
+            #         inner["decl"] = first.identifiers[0]
+            #     else:
+            #         inner["decls"] = first.identifiers
         elif mathlib_formalisations:
             first = mathlib_formalisations[0]
-            if first.identifiers is not None:
-                if len(first.identifiers) == 1:
-                    inner["decl"] = first.identifiers[0]
-                else:
-                    inner["decls"] = first.identifiers
+            # if first.identifiers is not None:
+            #     if len(first.identifiers) == 1:
+            #         inner["decl"] = first.identifiers[0]
+            #     else:
+            #         inner["decls"] = first.identifiers
         else:
             first = form[0]
             assert first.library == Library.External  # internal consistency check
             inner["url"] = first.url
-            # We conciously write out the identifiers of the external theorems,
+            # We consciously write out the identifiers of the external theorems,
             # so they can be added upstream. Since we use a different key from the 'main library'
             # case, tooling can distinguish these just fine.
-            inner["identifiers"] = first.identifiers
+            # inner["identifiers"] = first.identifiers
         if first.authors:
             # XXX: this is inconsistent with 100.yaml
             # the former uses 'author' always; the 1000+ theorems project always uses 'authors'

--- a/sync_mathlib_data.py
+++ b/sync_mathlib_data.py
@@ -37,6 +37,13 @@ class FormalizationStatus(Enum):
     # The full proof of a result was formalized.
     FullProof = auto()
 
+    @staticmethod
+    def from_str(input: str) -> FormalizationStatus:
+        return {
+            "formalized": FormalizationStatus.FullProof,
+            "statement": FormalizationStatus.Statement,
+        }[input]
+
 
 # In what library does the formalization appear?
 class Library(Enum):
@@ -47,6 +54,14 @@ class Library(Enum):
     MainLibrary = auto()
     # External to the main or standard library (e.g., a dedicated repository) ("X")
     External = auto()
+
+    @staticmethod
+    def from_str(input: str) -> Library:
+        return {
+            "S": Library.StandardLibrary,
+            "L": Library.MainLibrary,
+            "X": Library.External,
+        }[input]
 
 
 class FormalisationEntry(NamedTuple):
@@ -80,17 +95,8 @@ class TheoremEntry(NamedTuple):
 
 
 def _parse_formalization_entry(entry: dict) -> FormalisationEntry:
-    form = {
-        "formalized": FormalizationStatus.FullProof,
-        "statement": FormalizationStatus.Statement,
-    }
-    status = form[entry["status"]]
-    lib = {
-        "S": Library.StandardLibrary,
-        "L": Library.MainLibrary,
-        "X": Library.External,
-    }
-    library = lib[entry["library"]]
+    status = FormalizationStatus.from_str(entry["status"])
+    library = Library.from_str(entry["library"])
     identifiers = entry.get("identifiers")
     if library == Library.External and identifiers is None:
         print("invalid data: external formalisations should add precise identifiers!", file=sys.stderr)

--- a/sync_mathlib_data.py
+++ b/sync_mathlib_data.py
@@ -341,20 +341,21 @@ def update_data_from_downstream_yaml(input_file: str) -> None:
         elif new_entry_typed and upstream_entry:
             if len(upstream_entry) > 1:
                 print(f"theorem {id_with_suffix} has one Lean formalization downstream, but {len(upstream_entry)} upstream!")
-                # TODO: what now?
+                print("skipping data updates: please do so manually")
             else:
-                print(f"comparing formalisations for theorem {id_with_suffix}...")
+                # print(f"comparing formalisations for theorem {id_with_suffix}...")
                 if new_entry_typed != upstream_entry[0]:
                     def compare(downstream, upstream, field: str) -> None:
                         if downstream != upstream:
                             print(f"entries differ in field {field}: downstream declaration has value\n  {downstream}\n while upstream has\n  {upstream}")
-                    print("formalisations are different! overwriting with downstream data")
+                    print("formalizations entries are different!")
                     compare(new_entry_typed.status, upstream_entry[0].status, "status")
                     compare(new_entry_typed.library, upstream_entry[0].library, "library")
                     compare(new_entry_typed.url, upstream_entry[0].url, "URL")
                     compare(new_entry_typed.authors, upstream_entry[0].authors, "authors")
                     compare(new_entry_typed.date, upstream_entry[0].date, "date")
                     compare(new_entry_typed.comment, upstream_entry[0].comment, "comment")
+                    print(f"overwriting file _thms/{id_with_suffix}.md with downstream data")
                     # TODO: actually overwrite!
                 else:
                     print(f"info: formalizations for theorem {id_with_suffix} have the same data")

--- a/sync_mathlib_data.py
+++ b/sync_mathlib_data.py
@@ -402,7 +402,7 @@ def update_data_from_downstream_yaml(input_file: str) -> None:
             # `ruamel` seems to be better here... for now, we decide to not care
             title = _parse_title_inner(upstream_data["wikipedia_links"])
             with open(upstream_file, 'w') as f:
-                yamls = yaml.dump(upstream_data, indent=2, sort_keys=False)
+                yamls = yaml.dump(upstream_data, allow_unicode=True, indent=2, sort_keys=False)
                 f.write(f"---\n# {title}\n\n{yamls}\n---")
 
 

--- a/sync_mathlib_data.py
+++ b/sync_mathlib_data.py
@@ -295,11 +295,12 @@ def generate_downstream_file() -> None:
                 print(f"warning: file {os.path.join(THMS_DIR, file)} contains invalid input, ignoring", file=sys.stderr)
                 continue
             theorems.append(entry)
-    # Sort alphabetically according to wikidata ID.
+    # Sort alphabetically according to wikidata ID
+    # (more precisely, according to the number of the ID: Q42 comes before Q100).
     # FUTURE: also use MSC classification?
     # Write out a new yaml file for this, again.
     with open("generated-1000.yaml", "w") as f:
-        f.write("\n".join([_write_entry_for_downstream(thm) for thm in sorted(theorems, key=lambda t: t.wikidata)]))
+        f.write("\n".join([_write_entry_for_downstream(thm) for thm in sorted(theorems, key=lambda t: int(t.wikidata[1:]))]))
     print("Careful: the generated file does not contain declaration names. "
         "Be careful with manually merging the updated file!")
 

--- a/sync_mathlib_data.py
+++ b/sync_mathlib_data.py
@@ -371,7 +371,10 @@ def update_data_from_downstream_yaml(input_file: str) -> None:
                     print(f"info: formalizations entries for {id_with_suffix} are different!")
                     compare(new_entry_typed.status, upstream_entry[0].status, "status")
                     compare(new_entry_typed.library, upstream_entry[0].library, "library")
-                    compare(new_entry_typed.url, upstream_entry[0].url, "URL")
+                    if "decl" in entry or "decls" in entry:
+                        expected = f"https://leanprover-community.github.io/1000.html#{id_with_suffix}"
+                        if not (new_entry_typed.url, upstream_entry[0].url == (None, expected)):
+                            compare(new_entry_typed.url, upstream_entry[0].url, "URL")
                     compare(new_entry_typed.authors, upstream_entry[0].authors, "authors")
                     compare(new_entry_typed.date, upstream_entry[0].date, "date")
                     compare(new_entry_typed.comment, upstream_entry[0].comment, "comment")

--- a/sync_mathlib_data.py
+++ b/sync_mathlib_data.py
@@ -218,18 +218,22 @@ def _write_entry(entry: TheoremEntry) -> str:
         mathlib_formalisations = [f for f in form if f.library == Library.MainLibrary]
         if stdlib_formalisations:
             first = stdlib_formalisations[0]
-            # if first.identifiers is not None:
-            #     if len(first.identifiers) == 1:
-            #         inner["decl"] = first.identifiers[0]
-            #     else:
-            #         inner["decls"] = first.identifiers
+            # The same comment about declaration names applies.
+            if first.status == FormalizationStatus.FullProof:
+                inner["url"] = first.url
         elif mathlib_formalisations:
             first = mathlib_formalisations[0]
-            # if first.identifiers is not None:
-            #     if len(first.identifiers) == 1:
-            #         inner["decl"] = first.identifiers[0]
-            #     else:
-            #         inner["decls"] = first.identifiers
+            # URLs specified are of the form https://leanprover-community.github.io/1000.html#Q11518.
+            # We cannot easily parse the declaration from that, so omit it.
+            # (Could one add a comment like "# decl: cannot be inserted automatically" instead?)
+
+            # Future: one could try to hackily parse the code at
+            # https://leanprover-community.github.io/1000.html#Q11518;
+            # a "docs" link points to a URL like
+            # https://leanprover-community.github.io/mathlib4_docs/Mathlib/Geometry/Euclidean/Angle/Unoriented/RightAngle.html#EuclideanGeometry.dist_sq_eq_dist_sq_add_dist_sq_iff_angle_eq_pi_div_two,
+            # in which "EuclideanGeometry.dist_sq_eq_dist_sq_add_dist_sq_iff_angle_eq_pi_div_two"
+            # (the part after a #) is the declaration name.
+            # For several declarations, one would parse all declaration names.
         else:
             first = form[0]
             assert first.library == Library.External  # internal consistency check
@@ -265,6 +269,8 @@ def regenerate_from_upstream() -> None:
     # Write out a new yaml file for this, again.
     with open("generated-1000.yaml", "w") as f:
         f.write("\n".join([_write_entry(thm) for thm in sorted(theorems, key=lambda t: t.wikidata)]))
+    print("Careful: the generated file does not contain declaration names."
+        "Be careful with manually merging the updated file!")
 
 
 # todo: update this!

--- a/sync_mathlib_data.py
+++ b/sync_mathlib_data.py
@@ -260,14 +260,16 @@ def regenerate_from_upstream() -> None:
     for file in theorem_entry_files:
         with open(os.path.join('_thm', file), "r") as f:
             entry = _parse_theorem_entry(f.readlines())
-            if entry:
-                theorems.append(entry)
+            if entry is None:
+                print(f"warning: file _thm/{file} contains invalid input, ignoring", file=sys.stderr)
+                continue
+            theorems.append(entry)
     # Sort alphabetically according to wikidata ID.
     # FUTURE: also use MSC classification?
     # Write out a new yaml file for this, again.
     with open("generated-1000.yaml", "w") as f:
         f.write("\n".join([_write_entry(thm) for thm in sorted(theorems, key=lambda t: t.wikidata)]))
-    print("Careful: the generated file does not contain declaration names."
+    print("Careful: the generated file does not contain declaration names. "
         "Be careful with manually merging the updated file!")
 
 

--- a/sync_mathlib_data.py
+++ b/sync_mathlib_data.py
@@ -90,10 +90,13 @@ class FormalisationEntry(NamedTuple):
 # Parse a typed version of a formalisation entry from its raw version.
 # XXX: this assumes all entries are well-typed, for now
 def parse_formalization_entry(entry: FormalizationEntryRaw) -> FormalisationEntry:
+    if not isinstance(entry, FormalizationEntryRaw):
+        print("foo")
+        print(entry)
     return FormalisationEntry(
-        FormalizationStatus.from_str(entry.status),
-        Library.from_str(entry.library),
-        entry.url, entry.authors, entry.date, entry.comment
+        FormalizationStatus.from_str(entry['status']),
+        Library.from_str(entry['library']),
+        entry['url'], entry.get('authors'), entry.get('date'), entry.get('comment'),
     )
 
 

--- a/sync_mathlib_data.py
+++ b/sync_mathlib_data.py
@@ -50,6 +50,12 @@ class FormalizationStatus(Enum):
             "formalized": FormalizationStatus.FullProof,
             "statement": FormalizationStatus.Statement,
         }.get(input)
+    @staticmethod
+    def as_str(entry) -> str:
+        return {
+            FormalizationStatus.FullProof: "formalized",
+            FormalizationStatus.Statement: "statement",
+        }[entry]
 
 
 # In what library does the formalization appear?
@@ -69,6 +75,13 @@ class Library(Enum):
             "L": Library.MainLibrary,
             "X": Library.External,
         }.get(input)
+    @staticmethod
+    def as_str(entry) -> str:
+        return {
+            Library.StandardLibrary: "S",
+            Library.MainLibrary: "L",
+            Library.External: "X"
+        }[entry]
 
 
 # "Raw" version of a formalisation entry: not typed yet.
@@ -367,33 +380,29 @@ def update_data_from_downstream_yaml(input_file: str) -> None:
         if overwrite:
             url = "TODO" # depends
             inner = {
-                "status": "TODO",#as_str(new_entry_typed.status),
-                "library": "TODO", #
-                "url": new_entry[url],
-                #"authors":
-
+                "status": FormalizationStatus.as_str(new_entry_typed.status),
+                "library": Library.as_str(new_entry_typed.library),
+                "url": f"https://leanprover-community.github.io/1000.html#{id_with_suffix}",
             }
+            if new_entry_typed.authors:
+                inner["authors"] = new_entry_typed.authors
+            if new_entry_typed.date:
+                inner["date"] = new_entry_typed.date
+            if new_entry_typed.comment:
+                inner["comment"] = new_entry_typed.comment
             upstream_data["lean"] = [inner]
-
+            print(inner)
         #     # Augment the original file with information about the Lean formalisation.
         #     decl = [entry.get("decl")] or entry.get("decls")
-        #     inner = {"status": "formalized"}
         #     if decl:
-        #         # XXX: we assume no items came from the standard library...
-        #         inner["library"] = "M"
         #         # We link an URL that "auto-fixes" itself: have doc-gen search for the declaration.
         #         # As we know it exists, that will work fine :-)
         #         inner["identifiers"] = decl
         #         decl = f"https://leanprover-community.github.io/mathlib4_docs/find/?pattern={decl[0]}#doc"
         #     else:
-        #         inner["library"] = "X"
         #         inner["url"] = entry["url"]
-        #         inner["identifiers"] = entry["identifiers"]
         #     if "author" in entry:
         #         inner["authors"] = entry["author"].split(" and ")
-        #     if "date" in entry:
-        #         inner["date"] = entry["date"]
-        #     upstream_data["lean"] = [inner]
         #     # Human-readable theorem title from the upstream file.
         #     # We're not preserving (for now) if this was a section or sub-section.
         #     # XXX: the generated formatting is not exactly the same, because yaml.dump...

--- a/sync_mathlib_data.py
+++ b/sync_mathlib_data.py
@@ -256,7 +256,8 @@ def _write_entry(entry: TheoremEntry) -> str:
     return yaml.dump({key: inner}, sort_keys=False, allow_unicode=True)
 
 
-def regenerate_from_upstream() -> None:
+# Generate a file 1000.yaml from this repository's _thm folder.
+def generate_downstream_file() -> None:
     # Determine the list of theorem entry files.
     theorem_entry_files = []
     with os.scandir('_thm') as entries:
@@ -279,11 +280,13 @@ def regenerate_from_upstream() -> None:
         "Be careful with manually merging the updated file!")
 
 
-# todo: update this!
-def regenerate_upstream_from_yaml(dest_dir: str) -> None:
-    with open(os.path.join("docs", "1000.yaml"), "r") as f:
-        data_1000_yaml = yaml.safe_load(f)
-    for id_with_suffix, entry in data_1000_yaml.items():
+# Update this repository's data about Lean formalisations with the contents
+# in a yaml file |input_file|.
+def update_data_from_downstream_yaml(input_file: str) -> None:
+    with open(input_file, "r") as f:
+        downstream_yaml_data = yaml.safe_load(f)
+    # TODO: update this function!
+    for id_with_suffix, entry in downstream_yaml_data.items():
         has_formalisation = "decl" in entry or "decls" in entry or "identifiers" in entry
         # For each downstream declaration, read in the "upstream" yaml file and compare with the
         # downstream result.
@@ -336,14 +339,14 @@ if __name__ == "__main__":
     import sys
     match sys.argv.get(1):
         case "--downstream":
-            regenerate_from_upstream()
+            generate_downstream_file()
         case "--upstream":
             input_file = sys.argv.get(2)
             if input_file is None:
                 print("error: please specify the input file to read from: "
                     "usage: python3 sync_mathlib_data.py --upstream <filename.yaml>", file=sys.stderr)
                 sys.exit(1)
-            pass  # regenerate_upstream_from_yaml("../1000-plus.github.io/_thm")
+            update_data_from_downstream_yaml(input_file)
         case _:
             print("Please specify what you want to do: pass the --downstream option to regenerate a file 1000.yaml, "
                 "pass --upstream <filename.yaml> to update the theorem data files in this repository "

--- a/sync_mathlib_data.py
+++ b/sync_mathlib_data.py
@@ -295,18 +295,18 @@ def update_data_from_downstream_yaml(input_file: str) -> None:
         (status, library) = (None, None)
         new_entry_typed = None
         if "statement" in entry:
-            (status, library) = ("statement", "L")
+            (status, library) = (FormalizationStatus.Statement, Library.MainLibrary)
             new_entry["status"] = "statement"
             new_entry["library"] = "L"
         # This means the full proof is formalised within mathlib.
         # mathlib validates that at most one of has_statement and has_formalisation holds.
         elif "decl" in entry or "decls" in entry:
-            (status, library) = ("formalized", "L")
+            (status, library) = (FormalizationStatus.FullProof, Library.MainLibrary)
             new_entry["status"] = "formalized"
             new_entry["library"] = "L"
         # A URL field means an external formalisation exists.
         elif "url" in entry:
-            (status, library) = ("formalized", "X")
+            (status, library) = (FormalizationStatus.FullProof, Library.External)
             new_entry["status"] = "formalized"
             new_entry["library"] = "X"
         if new_entry:
@@ -343,6 +343,12 @@ def update_data_from_downstream_yaml(input_file: str) -> None:
                 print(f"comparing formalisations for theorem {id_with_suffix}...")
                 if new_entry_typed != upstream_entry[0]:
                     print("formalisations are different! overwriting with downstream data")
+                    print(new_entry_typed.status, upstream_entry[0].status)
+                    print(new_entry_typed.library, upstream_entry[0].library)
+                    print(new_entry_typed.url, upstream_entry[0].url)
+                    print(new_entry_typed.authors, upstream_entry[0].authors)
+                    print(new_entry_typed.date, upstream_entry[0].date)
+                    print(new_entry_typed.comment, upstream_entry[0].comment)
                     # TODO: actually overwrite!
                 else:
                     print("have the same data, nothing to do!")

--- a/sync_mathlib_data.py
+++ b/sync_mathlib_data.py
@@ -221,17 +221,17 @@ def regenerate_from_upstream(_args) -> None:
     with os.scandir(dir) as entries:
         theorem_entry_files = [entry.name for entry in entries if entry.is_file()]
     # Parse each entry file into a theorem entry.
-    thms: List[TheoremEntry | None] = []
+    theorems: List[TheoremEntry] = []
     for file in theorem_entry_files:
         with open(os.path.join(dir, file), "r") as f:
-            thms.append(_parse_theorem_entry(f.readlines()))
+            entry = _parse_theorem_entry(f.readlines())
+            if entry:
+                theorems.append(entry)
     # Sort alphabetically according to wikidata ID.
     # FUTURE: also use MSC classification?
-    filtered: List[TheoremEntry] = filter(lambda t: t is not None, thms)
-
     # Write out a new yaml file for this, again.
     with open(os.path.join("docs", "1000.yaml"), "w") as f:
-        f.write("\n".join([_write_entry(thm) for thm in sorted(filtered, key=lambda t: t.wikidata)]))
+        f.write("\n".join([_write_entry(thm) for thm in sorted(theorems, key=lambda t: t.wikidata)]))
 
 
 def regenerate_upstream_from_yaml(dest_dir: str) -> None:

--- a/sync_mathlib_data.py
+++ b/sync_mathlib_data.py
@@ -378,10 +378,11 @@ def update_data_from_downstream_yaml(input_file: str) -> None:
                     print(f"info: formalizations for theorem {id_with_suffix} have the same data")
 
         if overwrite:
-            url = "TODO" # depends
             inner = {
                 "status": FormalizationStatus.as_str(new_entry_typed.status),
                 "library": Library.as_str(new_entry_typed.library),
+                # We conciously choose such URLs not containing declaration names,
+                # as these are more stable.
                 "url": f"https://leanprover-community.github.io/1000.html#{id_with_suffix}",
             }
             if new_entry_typed.authors:
@@ -391,26 +392,15 @@ def update_data_from_downstream_yaml(input_file: str) -> None:
             if new_entry_typed.comment:
                 inner["comment"] = new_entry_typed.comment
             upstream_data["lean"] = [inner]
-            print(inner)
-        #     # Augment the original file with information about the Lean formalisation.
-        #     decl = [entry.get("decl")] or entry.get("decls")
-        #     if decl:
-        #         # We link an URL that "auto-fixes" itself: have doc-gen search for the declaration.
-        #         # As we know it exists, that will work fine :-)
-        #         inner["identifiers"] = decl
-        #         decl = f"https://leanprover-community.github.io/mathlib4_docs/find/?pattern={decl[0]}#doc"
-        #     else:
-        #         inner["url"] = entry["url"]
-        #     if "author" in entry:
-        #         inner["authors"] = entry["author"].split(" and ")
-        #     # Human-readable theorem title from the upstream file.
-        #     # We're not preserving (for now) if this was a section or sub-section.
-        #     # XXX: the generated formatting is not exactly the same, because yaml.dump...
-        #     # `ruamel` seems to be better here... for now, we decide to not care
-        #     title = _parse_title_inner(upstream_data["wikipedia_links"])
-        #     with open(os.path.join(dest_dir, f"{id_with_suffix}.md"), 'w') as f:
-        #         yamls = yaml.dump(upstream_data, indent=2, sort_keys=False)
-        #         f.write(f"---\n# {title}\n\n{yamls}\n---")
+            # Human-readable theorem title from the upstream file.
+            # We're not preserving (for now) if this was a section or sub-section.
+
+            # XXX: the generated formatting is not exactly the same, because yaml.dump...
+            # `ruamel` seems to be better here... for now, we decide to not care
+            title = _parse_title_inner(upstream_data["wikipedia_links"])
+            with open(os.path.join(dest_dir, f"{id_with_suffix}.md"), 'w') as f:
+                yamls = yaml.dump(upstream_data, indent=2, sort_keys=False)
+                f.write(f"---\n# {title}\n\n{yamls}\n---")
 
 
 if __name__ == "__main__":

--- a/sync_mathlib_data.py
+++ b/sync_mathlib_data.py
@@ -71,8 +71,9 @@ class FormalizationEntryRaw:
     status: str
     library: str
     url: str
-    authors: Optional[List[str]]
-    date: Optional[datetime]
+    authors: Optional[List[str]] = None
+    date: Optional[datetime] = None
+    comment: Optional[str] = None
 
 
 class FormalisationEntry(NamedTuple):
@@ -80,7 +81,7 @@ class FormalisationEntry(NamedTuple):
     library: Library
     # A URL pointing to the formalization
     url: str
-    authors: Optional[str]
+    authors: Optional[List[str]]
     # Format `YYYY-MM-DD`, `YYYY-MM` or `YYYY` in the source file.
     date: Optional[datetime]
     comment: Optional[str]
@@ -169,12 +170,12 @@ def _parse_theorem_entry(contents: List[str]) -> TheoremEntry | None:
     formalisations = {}
     for (pa, raw) in passthrough.items():
         if raw:
-            entries = [parse_formalization_entry(entry) for entry in raw]
+            entries: List[FormalisationEntry] = [parse_formalization_entry(entry) for entry in raw]
             if None in entries:
                 return None
             formalisations[pa] = entries
         else:
-            formalisations[pa] = None
+            formalisations[pa] = []
     res = TheoremEntry(
         raw_thm.wikidata, raw_thm.id_suffix, raw_thm.msc_classification, raw_thm.wikipedia_links,
         formalisations

--- a/sync_mathlib_data.py
+++ b/sync_mathlib_data.py
@@ -396,18 +396,22 @@ def update_data_from_downstream_yaml(input_file: str) -> None:
 
 if __name__ == "__main__":
     import sys
-    match sys.argv.get(1):
+    if len(sys.argv) < 2:
+        print("Please specify what you want to do: pass the --downstream option to regenerate a file 1000.yaml or "
+            "pass --upstream <filename.yaml> to update the theorem data files in this repository "
+            "from a downstream .yaml file.", file=sys.stderr)
+        sys.exit(1)
+    match sys.argv[1]:
         case "--downstream":
             generate_downstream_file()
         case "--upstream":
-            input_file = sys.argv.get(2)
-            if input_file is None:
+            if len(sys.argv) == 2:
                 print("error: please specify the input file to read from: "
                     "usage: python3 sync_mathlib_data.py --upstream <filename.yaml>", file=sys.stderr)
                 sys.exit(1)
-            update_data_from_downstream_yaml(input_file)
-        case _:
-            print("Please specify what you want to do: pass the --downstream option to regenerate a file 1000.yaml, "
-                "pass --upstream <filename.yaml> to update the theorem data files in this repository "
-                "from a downstream .yaml file.", file=sys.stderr)
+            update_data_from_downstream_yaml(sys.argv[2])
+        case unexpected:
+            print(f"Unexpected argument '{unexpected}': usage is\n  python3 sync_mathlib_data.py --downstream\n"
+            "to regenerate a downstream file 1000.yaml or\n  python3 sync_mathlib_data.py --upstream <inputfile.yaml>\n"
+            "to update the theorem data files in this repository from a downstream .yaml file.", file=sys.stderr)
             sys.exit(1)

--- a/sync_mathlib_data.py
+++ b/sync_mathlib_data.py
@@ -38,7 +38,7 @@ class FormalizationStatus(Enum):
     FullProof = auto()
 
     @staticmethod
-    def from_str(input: str) -> FormalizationStatus:
+    def from_str(input: str):
         return {
             "formalized": FormalizationStatus.FullProof,
             "statement": FormalizationStatus.Statement,
@@ -56,7 +56,7 @@ class Library(Enum):
     External = auto()
 
     @staticmethod
-    def from_str(input: str) -> Library:
+    def from_str(input: str):
         return {
             "S": Library.StandardLibrary,
             "L": Library.MainLibrary,
@@ -213,29 +213,26 @@ def _write_entry(entry: TheoremEntry) -> str:
     return yaml.dump(res, sort_keys=False, allow_unicode=True)
 
 
-def regenerate_from_upstream(_args) -> None:
-    # FIXME: download the upstream files to a local directory; or
-    # if the --local option and a location are passed, look in that location instead.
-    # For now, the latter is used, with a hard-coded directory...
-    dir = "../1000-plus.github.io/_thm"
+def regenerate_from_upstream() -> None:
     # Determine the list of theorem entry files.
     theorem_entry_files = []
-    with os.scandir(dir) as entries:
+    with os.scandir('_thm') as entries:
         theorem_entry_files = [entry.name for entry in entries if entry.is_file()]
     # Parse each entry file into a theorem entry.
     theorems: List[TheoremEntry] = []
     for file in theorem_entry_files:
-        with open(os.path.join(dir, file), "r") as f:
+        with open(os.path.join('_thm', file), "r") as f:
             entry = _parse_theorem_entry(f.readlines())
             if entry:
                 theorems.append(entry)
     # Sort alphabetically according to wikidata ID.
     # FUTURE: also use MSC classification?
     # Write out a new yaml file for this, again.
-    with open(os.path.join("docs", "1000.yaml"), "w") as f:
+    with open("generated-1000.yaml", "w") as f:
         f.write("\n".join([_write_entry(thm) for thm in sorted(theorems, key=lambda t: t.wikidata)]))
 
 
+# todo: update this!
 def regenerate_upstream_from_yaml(dest_dir: str) -> None:
     with open(os.path.join("docs", "1000.yaml"), "r") as f:
         data_1000_yaml = yaml.safe_load(f)
@@ -291,5 +288,5 @@ def regenerate_upstream_from_yaml(dest_dir: str) -> None:
 if __name__ == "__main__":
     import sys
 
-    regenerate_from_upstream(sys.argv)
+    regenerate_from_upstream()
     # regenerate_upstream_from_yaml("../1000-plus.github.io/_thm")

--- a/sync_mathlib_data.py
+++ b/sync_mathlib_data.py
@@ -292,7 +292,7 @@ def update_data_from_downstream_yaml(input_file: str) -> None:
         # Newly created entry, based on the downstream entries.
         new_entry = {}
         # This means the statement (and only the statement) is formalised, within mathlib.
-        (status_library) = (None, None)
+        (status, library) = (None, None)
         new_entry_typed = None
         if "statement" in entry:
             (status, library) = ("statement", "L")
@@ -323,7 +323,7 @@ def update_data_from_downstream_yaml(input_file: str) -> None:
 
         # Read the _thm data file and compare data on Lean formalisations.
         upstream_entry = None
-        with open(os.path.join(dest_dir, f"{id_with_suffix}.md"), 'r') as f:
+        with open(os.path.join("_thm", f"{id_with_suffix}.md"), 'r') as f:
             contents = f.readlines()
             upstream_data = yaml.safe_load("".join(contents[1:-1]))
             upstream_lean_entry = _parse_theorem_entry(contents)

--- a/sync_mathlib_data.py
+++ b/sync_mathlib_data.py
@@ -365,21 +365,27 @@ def update_data_from_downstream_yaml(input_file: str) -> None:
                 print("skipping data updates: please do so manually")
             else:
                 if new_entry_typed != upstream_entry[0]:
-                    def compare(downstream, upstream, field: str) -> None:
+                    def compare(downstream, upstream, field: str) -> str:
                         if downstream != upstream:
-                            print(f"entries differ in field {field}: downstream declaration has value\n  {downstream}\nwhile upstream has\n  {upstream}")
-                    print(f"info: formalizations entries for {id_with_suffix} are different!")
-                    compare(new_entry_typed.status, upstream_entry[0].status, "status")
-                    compare(new_entry_typed.library, upstream_entry[0].library, "library")
+                            return f"entries differ in field {field}: downstream declaration has value\n  {downstream}\nwhile upstream has\n  {upstream}"
+                        return ""
+                    messages = []
+                    # print(f"info: formalizations entries for {id_with_suffix} are different!")
+                    messages.append(compare(new_entry_typed.status, upstream_entry[0].status, "status"))
+                    messages.append(compare(new_entry_typed.library, upstream_entry[0].library, "library"))
                     if "decl" in entry or "decls" in entry:
                         expected = f"https://leanprover-community.github.io/1000.html#{id_with_suffix}"
                         if not (new_entry_typed.url, upstream_entry[0].url == (None, expected)):
-                            compare(new_entry_typed.url, upstream_entry[0].url, "URL")
-                    compare(new_entry_typed.authors, upstream_entry[0].authors, "authors")
-                    compare(new_entry_typed.date, upstream_entry[0].date, "date")
-                    compare(new_entry_typed.comment, upstream_entry[0].comment, "comment")
-                    print(f"debug: overwriting file {upstream_file} with downstream data")
-                    overwrite = True
+                            messages.append(compare(new_entry_typed.url, upstream_entry[0].url, "URL"))
+                    messages.append(compare(new_entry_typed.authors, upstream_entry[0].authors, "authors"))
+                    messages.append(compare(new_entry_typed.date, upstream_entry[0].date, "date"))
+                    messages.append(compare(new_entry_typed.comment, upstream_entry[0].comment, "comment"))
+                    real_msg = [msg for msg in messages if msg]
+                    if real_msg:
+                        overwrite = True
+                        print(f"info: formalizations entries for {id_with_suffix} are different!")
+                        print(msg)
+                        print(f"debug: overwriting file {upstream_file} with downstream data")
                 else:
                     print(f"info: formalizations for theorem {id_with_suffix} have the same data")
 

--- a/sync_mathlib_data.py
+++ b/sync_mathlib_data.py
@@ -263,6 +263,9 @@ def _write_entry_for_downstream(entry: TheoremEntry) -> str:
             first = form[0]
             assert first.library == Library.External  # internal consistency check
             # We don't mentional external formalisations of just the statement in mathlib's file.
+            # NB: this will overwrite an "interesting" external URL with the upstream one.
+            # We cannot really help that; this is another change in the generated 1000.yaml file
+            # that should not be committed downstream.
             if first.status == FormalizationStatus.FullProof:
                 inner["url"] = first.url
         if first.authors:

--- a/sync_mathlib_data.py
+++ b/sync_mathlib_data.py
@@ -213,7 +213,14 @@ def _parse_title_inner(wiki_links: List[str]) -> str:
     if suf == "s":
         title += "s"
     if "|" in title:
-        title = title.partition("|")[2]
+        # We generally prefer wikipedia's lemma name over the display name
+        # in the list, as the former includes disambiguation with mathematical
+        # areas. (The latter does not; the wikipedia list adds it as a separate parenthetical.)
+        # Exceptions: if the link is to a sub-section, or doesn't contain the word
+        # "theorem", we use the displayed title.
+        (wikipedia_lemma, _, displayed) = title.partition("|")
+        prefer_display = "#" in wikipedia_lemma or "theorem" not in wikipedia_lemma
+        title = displayed if prefer_display else wikipedia_lemma
     return title
 
 def _parse_title(entry: TheoremEntry) -> str:

--- a/sync_mathlib_data.py
+++ b/sync_mathlib_data.py
@@ -318,8 +318,11 @@ def update_data_from_downstream_yaml(input_file: str) -> None:
             new_entry["date"] = entry["date"]
         if "comment" in entry:
             new_entry["comment"] = entry["comment"]
+        authors = entry.get("authors")
+        if authors:
+            authors = authors.split(" and ")
         if status:
-            new_entry_typed = FormalisationEntry(status, library, entry.get("url"), entry.get("authors"), entry.get("date"), entry.get("comment"))
+            new_entry_typed = FormalisationEntry(status, library, entry.get("url"), authors, entry.get("date"), entry.get("comment"))
 
         # Read the _thm data file and compare data on Lean formalisations.
         upstream_entry = None
@@ -342,16 +345,19 @@ def update_data_from_downstream_yaml(input_file: str) -> None:
             else:
                 print(f"comparing formalisations for theorem {id_with_suffix}...")
                 if new_entry_typed != upstream_entry[0]:
+                    def compare(downstream, upstream, field: str) -> None:
+                        if downstream != upstream:
+                            print(f"entries differ in field {field}: downstream declaration has value\n  {downstream}\n while upstream has\n  {upstream}")
                     print("formalisations are different! overwriting with downstream data")
-                    print(new_entry_typed.status, upstream_entry[0].status)
-                    print(new_entry_typed.library, upstream_entry[0].library)
-                    print(new_entry_typed.url, upstream_entry[0].url)
-                    print(new_entry_typed.authors, upstream_entry[0].authors)
-                    print(new_entry_typed.date, upstream_entry[0].date)
-                    print(new_entry_typed.comment, upstream_entry[0].comment)
+                    compare(new_entry_typed.status, upstream_entry[0].status, "status")
+                    compare(new_entry_typed.library, upstream_entry[0].library, "library")
+                    compare(new_entry_typed.url, upstream_entry[0].url, "URL")
+                    compare(new_entry_typed.authors, upstream_entry[0].authors, "authors")
+                    compare(new_entry_typed.date, upstream_entry[0].date, "date")
+                    compare(new_entry_typed.comment, upstream_entry[0].comment, "comment")
                     # TODO: actually overwrite!
                 else:
-                    print("have the same data, nothing to do!")
+                    print(f"info: formalizations for theorem {id_with_suffix} have the same data")
 
         # # For each downstream declaration, read in the "upstream" yaml file and compare with the
         # # downstream result.

--- a/sync_mathlib_data.py
+++ b/sync_mathlib_data.py
@@ -247,7 +247,7 @@ def _write_entry(entry: TheoremEntry) -> str:
         if first.authors:
             # NB: this is different from the 100 theorems project
             # 100 theorems names the field 'author'; this project uses 'authors'
-            inner["author"] = " and ".join(first.authors)
+            inner["authors"] = " and ".join(first.authors)
         # Add additional metadata, so no information is lost in the generated yaml file.
         if first.date:
             inner['date'] = first.date

--- a/sync_mathlib_data.py
+++ b/sync_mathlib_data.py
@@ -39,11 +39,11 @@ class FormalizationStatus(Enum):
     FullProof = auto()
 
     @staticmethod
-    def from_str(input: str):
+    def tryFrom_str(input: str):
         return {
             "formalized": FormalizationStatus.FullProof,
             "statement": FormalizationStatus.Statement,
-        }[input]
+        }.get(input)
 
 
 # In what library does the formalization appear?
@@ -57,12 +57,12 @@ class Library(Enum):
     External = auto()
 
     @staticmethod
-    def from_str(input: str):
+    def tryFrom_str(input: str):
         return {
             "S": Library.StandardLibrary,
             "L": Library.MainLibrary,
             "X": Library.External,
-        }[input]
+        }.get(input)
 
 
 # "Raw" version of a formalisation entry: not typed yet.
@@ -88,15 +88,13 @@ class FormalisationEntry(NamedTuple):
 
 
 # Parse a typed version of a formalisation entry from its raw version.
-# XXX: this assumes all entries are well-typed, for now
-def parse_formalization_entry(entry: FormalizationEntryRaw) -> FormalisationEntry:
-    if not isinstance(entry, FormalizationEntryRaw):
-        print("foo")
-        print(entry)
+def parse_formalization_entry(entry: FormalizationEntryRaw) -> FormalisationEntry | None:
+    status = FormalizationStatus.tryFrom_str(entry['status'])
+    library = Library.tryFrom_str(entry['library'])
+    if status is None or library is None:
+        return None
     return FormalisationEntry(
-        FormalizationStatus.from_str(entry['status']),
-        Library.from_str(entry['library']),
-        entry['url'], entry.get('authors'), entry.get('date'), entry.get('comment'),
+        status, library, entry['url'], entry.get('authors'), entry.get('date'), entry.get('comment'),
     )
 
 


### PR DESCRIPTION
This script works in two directions, as indicated by the `--downstream` or `--upstream` options.
The "downward" direction takes the data in the `_thm` folder and generates a file 1000.yaml
containing all relevant information about all the Lean formalisations:
that file is used in Lean's mathlib library.

The "upward" direction reads the file 1000.yaml from mathlib (passed in as a local file),
compares the data about Lean formalisations with the one in this repository and
adds/overwrites this (and only this) data.
This script depends on the details of the file 1000.yaml in mathlib, so should evolve with any changes there.

This is the script used for generating #11.