### PR TITLE
fix: correct spelling of three names; remove an extraneous space

### DIFF
--- a/_thm/Q1051404.md
+++ b/_thm/Q1051404.md
@@ -4,5 +4,5 @@
 wikidata: Q1051404
 msc_classification: "26"
 wikipedia_links:
-  - "[[Cesaro's theorem|Cesàro's theorem]]"
+  - "[[Cesàro's theorem|Cesàro's theorem]]"
 ---

--- a/_thm/Q4894565.md
+++ b/_thm/Q4894565.md
@@ -4,5 +4,5 @@
 wikidata: Q4894565
 msc_classification: "41"
 wikipedia_links:
-  - "[[Bernstein's theorem (approximation theory) |Bernstein's theorem]]"
+  - "[[Bernstein's theorem (approximation theory)|Bernstein's theorem]]"
 ---

--- a/_thm/Q897769.md
+++ b/_thm/Q897769.md
@@ -1,8 +1,8 @@
 ---
-# König's theorem
+# Kőnig's theorem
 
 wikidata: Q897769
 msc_classification: "05"
 wikipedia_links:
-  - "[[Kőnig's theorem (graph theory)|König's theorem]]"
+  - "[[Kőnig's theorem (graph theory)|Kőnig's theorem]]"
 ---

--- a/_thm/Q973359.md
+++ b/_thm/Q973359.md
@@ -1,8 +1,8 @@
 ---
-# Rado's theorem
+# Radó's theorem
 
 wikidata: Q973359
 msc_classification: "43"
 wikipedia_links:
-  - "[[Radó's theorem (harmonic functions)|Rado's theorem]]"
+  - "[[Radó's theorem (harmonic functions)|Radó's theorem]]"
 ---


### PR DESCRIPTION
The same changes have been made upstream.