### PR TITLE
allow optional identifier 

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For each formalization in each proof assistant, we record the following informat
   - "X": external to the main or standard library (e.g. a dedicated repository)
 * `url`: a URL pointing to the formalization
 * `authors`:  list of authors of the formalisation; optional
-* `identifier`:  (optional). The name of the result/statement in a proof assistant. Can be a list of statements.
+* `identifiers`:  (optional). A list of names for the result/statement.
 * `date`:  (optional). Format: `YYYY`, `YYYY-MM` or `YYYY-MM-DD`
 * `comment`: (optional)
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ For each formalization in each proof assistant, we record the following informat
   - "L": main (biggest) mathematical library (afp, hol light outside standard library, mathcomp, mathlib, mml, set.mm)
   - "X": external to the main or standard library (e.g. a dedicated repository)
 * `url`: a URL pointing to the formalization
-* `authors`:  list of authors of the formalisation; optional
-* `identifiers`:  (optional). A list of names for the result/statement.
-* `date`:  (optional). Format: `YYYY`, `YYYY-MM` or `YYYY-MM-DD`
+* `authors`: list of authors of the formalisation; optional
+* `identifiers`: (optional). A list of names for the result/statement.
+* `date`: (optional). Format: `YYYY`, `YYYY-MM` or `YYYY-MM-DD`
 * `comment`: (optional)
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ For each formalization in each proof assistant, we record the following informat
   - "X": external to the main or standard library (e.g. a dedicated repository)
 * `url`: a URL pointing to the formalization
 * `authors`:  list of authors of the formalisation; optional
+* `identifier`:  (optional). The name of the result/statement in a proof assistant.
 * `date`:  (optional). Format: `YYYY`, `YYYY-MM` or `YYYY-MM-DD`
 * `comment`: (optional)
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For each formalization in each proof assistant, we record the following informat
   - "X": external to the main or standard library (e.g. a dedicated repository)
 * `url`: a URL pointing to the formalization
 * `authors`:  list of authors of the formalisation; optional
-* `identifier`:  (optional). The name of the result/statement in a proof assistant.
+* `identifier`:  (optional). The name of the result/statement in a proof assistant. Can be a list of statements.
 * `date`:  (optional). Format: `YYYY`, `YYYY-MM` or `YYYY-MM-DD`
 * `comment`: (optional)
 


### PR DESCRIPTION
For Lean, this should be automatically added/modified by the transfer script from the Mathlib source of truth (cc @grunweg) (but this has low priority)