### PR TITLE
feat(sync_mathlib_data): allow, add and recognise identifier information

### DIFF
--- a/_thm/Q1032886.md
+++ b/_thm/Q1032886.md
@@ -11,5 +11,7 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q1032886
   authors:
   - David Wärn
+  identifiers:
+  - Combinatorics.Line.exists_mono_in_high_dimension
 
 ---

--- a/_thm/Q1033910.md
+++ b/_thm/Q1033910.md
@@ -11,22 +11,24 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q1033910
   authors:
   - Mario Carneiro
+  identifiers:
+  - Function.Embedding.schroeder_bernstein
 coq:
 - status: formalized
   library: X
-  url: "https://github.com/coq-contribs/schroeder/blob/master/Schroeder.v"
+  url: https://github.com/coq-contribs/schroeder/blob/master/Schroeder.v
   authors:
   - Hugo Herbelin
 isabelle:
 - status: formalized
   library: S
-  url: "https://isabelle.in.tum.de/dist/library/HOL/HOL/Inductive.html"
+  url: https://isabelle.in.tum.de/dist/library/HOL/HOL/Inductive.html
   authors:
   - Tobias Nipkow
 metamath:
 - status: formalized
   library: L
-  url: "https://us.metamath.org/mpeuni/sbth.html"
+  url: https://us.metamath.org/mpeuni/sbth.html
   authors:
   - Norman Megill
   - Jim Kingdon
@@ -34,7 +36,7 @@ metamath:
 mizar:
 - status: formalized
   library: L
-  url: "https://mizar.uwb.edu.pl/version/current/html/knaster.html#T10"
+  url: https://mizar.uwb.edu.pl/version/current/html/knaster.html#T10
   authors:
   - Piotr Rudnicki
   - Andrzej Trybulec
@@ -42,7 +44,8 @@ mizar:
 hol_light:
 - status: formalized
   library: S
-  url: "https://github.com/jrh13/hol-light/blob/master/Library/card.ml"
+  url: https://github.com/jrh13/hol-light/blob/master/Library/card.ml
   authors:
   - John Harrison
+
 ---

--- a/_thm/Q1038716.md
+++ b/_thm/Q1038716.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q1038716
+  identifiers:
+  - AnalyticOnNhd.eqOn_of_preconnected_of_frequently_eq
 
 ---

--- a/_thm/Q1047749.md
+++ b/_thm/Q1047749.md
@@ -11,5 +11,7 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q1047749
   authors:
   - Jeremy Tan
+  identifiers:
+  - SimpleGraph.isTuranMaximal_iff_nonempty_iso_turanGraph
 
 ---

--- a/_thm/Q1050203.md
+++ b/_thm/Q1050203.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q1050203
+  identifiers:
+  - IsCompact.nonempty_sInter_of_directed_nonempty_isCompact_isClosed
 
 ---

--- a/_thm/Q1052678.md
+++ b/_thm/Q1052678.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q1052678
+  identifiers:
+  - dense_sInter_of_isOpen
 
 ---

--- a/_thm/Q1057919.md
+++ b/_thm/Q1057919.md
@@ -9,5 +9,10 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q1057919
+  identifiers:
+  - Sylow.exists_subgroup_card_pow_prime
+  - Sylow.isPretransitive_of_finite
+  - Sylow.card_dvd_index
+  - card_sylow_modEq_one
 
 ---

--- a/_thm/Q1065257.md
+++ b/_thm/Q1065257.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q1065257
+  identifiers:
+  - tendsto_of_tendsto_of_tendsto_of_le_of_le'
 
 ---

--- a/_thm/Q1065966.md
+++ b/_thm/Q1065966.md
@@ -9,5 +9,9 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q1065966
+  identifiers:
+  - QuotientGroup.quotientKerEquivRange
+  - QuotientGroup.quotientInfEquivProdNormalQuotient
+  - QuotientGroup.quotientQuotientEquivQuotient
 
 ---

--- a/_thm/Q1067156.md
+++ b/_thm/Q1067156.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q1067156
+  identifiers:
+  - MeasureTheory.tendsto_integral_of_dominated_convergence
 
 ---

--- a/_thm/Q1067156X.md
+++ b/_thm/Q1067156X.md
@@ -10,5 +10,8 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q1067156X
+  identifiers:
+  - MeasureTheory.FiniteMeasure.tendsto_lintegral_nn_of_le_const
+  - MeasureTheory.tendsto_lintegral_nn_filter_of_le_const
 
 ---

--- a/_thm/Q1068085.md
+++ b/_thm/Q1068085.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q1068085
+  identifiers:
+  - LinearMap.continuous_of_isClosed_graph
 
 ---

--- a/_thm/Q1068283.md
+++ b/_thm/Q1068283.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q1068283
+  identifiers:
+  - FirstOrder.Language.exists_elementaryEmbedding_card_eq
 
 ---

--- a/_thm/Q1068976.md
+++ b/_thm/Q1068976.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q1068976
+  identifiers:
+  - MvPolynomial.vanishingIdeal_zeroLocus_eq_radical
 
 ---

--- a/_thm/Q1082910.md
+++ b/_thm/Q1082910.md
@@ -12,5 +12,7 @@ lean:
   authors:
   - Bhavik Mehta
   - Aaron Anderson
+  identifiers:
+  - Theorems100.partition_theorem
 
 ---

--- a/_thm/Q1097021.md
+++ b/_thm/Q1097021.md
@@ -12,6 +12,8 @@ lean:
   authors:
   - Alex J. Best
   - Yaël Dillies
+  identifiers:
+  - MeasureTheory.exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure
   date: 2021
 
 ---

--- a/_thm/Q11352023.md
+++ b/_thm/Q11352023.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q11352023
   authors:
   - Igor Khavkine
+  identifiers:
+  - MeasureTheory.tendstoInMeasure_iff_tendsto_Lp
   date: 2024
 
 ---

--- a/_thm/Q1137014.md
+++ b/_thm/Q1137014.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q1137014
+  identifiers:
+  - isCompact_pi_infinite
 
 ---

--- a/_thm/Q1137206.md
+++ b/_thm/Q1137206.md
@@ -11,5 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q1137206
   authors:
   - Moritz Doll
+  identifiers:
+  - taylor_mean_remainder_lagrange
+  - taylor_mean_remainder_cauchy
 
 ---

--- a/_thm/Q1139041.md
+++ b/_thm/Q1139041.md
@@ -1,5 +1,5 @@
 ---
-# Cauchy's theorem
+# Cauchy's theorem (group theory)
 
 wikidata: Q1139041
 msc_classification: '20'
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q1139041
+  identifiers:
+  - exists_prime_orderOf_dvd_card
 
 ---

--- a/_thm/Q1149022.md
+++ b/_thm/Q1149022.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q1149022
+  identifiers:
+  - MeasureTheory.integral_prod
 
 ---

--- a/_thm/Q1149458.md
+++ b/_thm/Q1149458.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q1149458
+  identifiers:
+  - FirstOrder.Language.Theory.isSatisfiable_iff_isFinitelySatisfiable
 
 ---

--- a/_thm/Q11518.md
+++ b/_thm/Q11518.md
@@ -11,5 +11,7 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q11518
   authors:
   - Joseph Myers
+  identifiers:
+  - EuclideanGeometry.dist_sq_eq_dist_sq_add_dist_sq_iff_angle_eq_pi_div_two
 
 ---

--- a/_thm/Q1153584.md
+++ b/_thm/Q1153584.md
@@ -9,5 +9,8 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q1153584
+  identifiers:
+  - MeasureTheory.integral_tendsto_of_tendsto_of_antitone
+  - MeasureTheory.lintegral_tendsto_of_tendsto_of_monotone
 
 ---

--- a/_thm/Q1186808.md
+++ b/_thm/Q1186808.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q1186808
+  identifiers:
+  - Choose.lucas_theorem
 
 ---

--- a/_thm/Q1187646.md
+++ b/_thm/Q1187646.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q1187646
+  identifiers:
+  - QuotientGroup.quotientKerEquivRange
 
 ---

--- a/_thm/Q1188392.md
+++ b/_thm/Q1188392.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q1188392
+  identifiers:
+  - Nat.zeckendorfEquiv
 
 ---

--- a/_thm/Q1191319.md
+++ b/_thm/Q1191319.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q1191319
+  identifiers:
+  - MeasureTheory.Measure.absolutelyContinuous_iff_withDensity_rnDeriv_eq
 
 ---

--- a/_thm/Q1191709.md
+++ b/_thm/Q1191709.md
@@ -11,5 +11,7 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q1191709
   authors:
   - Kexing Ying
+  identifiers:
+  - MeasureTheory.tendstoUniformlyOn_of_ae_tendsto
 
 ---

--- a/_thm/Q1194053.md
+++ b/_thm/Q1194053.md
@@ -9,6 +9,8 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q1194053
+  identifiers:
+  - TopologicalSpace.metrizableSpace_of_t3_secondCountable
   comment: Urysohn's metrization theorem (only)
 
 ---

--- a/_thm/Q1217677.md
+++ b/_thm/Q1217677.md
@@ -12,5 +12,8 @@ lean:
   authors:
   - Yury G. Kudryashov (first)
   - Benjamin Davidson (second)
+  identifiers:
+  - intervalIntegral.integral_hasStrictDerivAt_of_tendsto_ae_right
+  - intervalIntegral.integral_eq_sub_of_hasDeriv_right_of_le
 
 ---

--- a/_thm/Q1243340.md
+++ b/_thm/Q1243340.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q1243340
   authors:
   - Bhavik Mehta
+  identifiers:
+  - doublyStochastic_eq_convexHull_permMatrix
   date: 2024
 
 ---

--- a/_thm/Q1259814.md
+++ b/_thm/Q1259814.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q1259814
+  identifiers:
+  - subgroupIsFreeOfIsFree
 
 ---

--- a/_thm/Q1306095.md
+++ b/_thm/Q1306095.md
@@ -9,6 +9,8 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q1306095
+  identifiers:
+  - exists_embedding_euclidean_of_compact
   comment: 'baby version: for compact manifolds; embedding into some *n*'
 
 ---

--- a/_thm/Q132469.md
+++ b/_thm/Q132469.md
@@ -9,6 +9,8 @@ lean:
 - status: statement
   library: L
   url: https://leanprover-community.github.io/1000.html#Q132469
+  identifiers:
+  - FermatLastTheorem
   comment: Formalisation of the proof is on-going in https://imperialcollegelondon.github.io/FLT/.
 
 ---

--- a/_thm/Q1346677.md
+++ b/_thm/Q1346677.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q1346677
+  identifiers:
+  - BoundedContinuousFunction.exists_extension_norm_eq_of_isClosedEmbedding
 
 ---

--- a/_thm/Q137164.md
+++ b/_thm/Q137164.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q137164
   authors:
   - Sébastien Gouëzel
+  identifiers:
+  - Besicovitch.exists_disjoint_closedBall_covering_ae
   date: 2021
 
 ---

--- a/_thm/Q1426292.md
+++ b/_thm/Q1426292.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q1426292
   authors:
   - Jireh Loreaux
+  identifiers:
+  - banach_steinhaus
   date: 2021
 
 ---

--- a/_thm/Q1457052.md
+++ b/_thm/Q1457052.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q1457052
   authors:
   - Mario Carneiro, Chris Hughes, Violeta Hernández
+  identifiers:
+  - exists_wellOrder
   date: 2017
 
 ---

--- a/_thm/Q1477053.md
+++ b/_thm/Q1477053.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q1477053
+  identifiers:
+  - BoundedContinuousFunction.arzela_ascoli
 
 ---

--- a/_thm/Q1506253.md
+++ b/_thm/Q1506253.md
@@ -11,5 +11,7 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q1506253
   authors:
   - Jeremy Avigad
+  identifiers:
+  - Nat.exists_infinite_primes
 
 ---

--- a/_thm/Q1542114.md
+++ b/_thm/Q1542114.md
@@ -5,11 +5,6 @@ wikidata: Q1542114
 msc_classification: '14'
 wikipedia_links:
 - '[[Bézout''s theorem]]'
-lean:
-- status: formalized
-  library: L
-  url: https://leanprover-community.github.io/1000.html#Q1542114
-  authors:
-  - mathlib
+
 
 ---

--- a/_thm/Q1566341.md
+++ b/_thm/Q1566341.md
@@ -11,5 +11,7 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q1566341
   authors:
   - David Wärn
+  identifiers:
+  - Hindman.FP_partition_regular
 
 ---

--- a/_thm/Q1568811.md
+++ b/_thm/Q1568811.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q1568811
   authors:
   - Kexing Ying
+  identifiers:
+  - MeasureTheory.SignedMeasure.exists_isCompl_positive_negative
   date: 2021
 
 ---

--- a/_thm/Q16251580.md
+++ b/_thm/Q16251580.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q16251580
   authors:
   - Mario Carneiro
+  identifiers:
+  - Pell.matiyasevic
   date: 2017
 
 ---

--- a/_thm/Q1632433.md
+++ b/_thm/Q1632433.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q1632433
   authors:
   - Vasily Nesterov
+  identifiers:
+  - Convex.helly_theorem
   date: 2023
 
 ---

--- a/_thm/Q1687147.md
+++ b/_thm/Q1687147.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q1687147
   authors:
   - Fox Thomson
+  identifiers:
+  - SetTheory.PGame.equiv_nim_grundyValue
   date: 2020
 
 ---

--- a/_thm/Q17005116.md
+++ b/_thm/Q17005116.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q17005116
   authors:
   - Yaël Dillies
+  identifiers:
+  - LatticeHom.birkhoffSet
   date: 2022
 
 ---

--- a/_thm/Q172298.md
+++ b/_thm/Q172298.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q172298
+  identifiers:
+  - Ideal.isPrimary_decomposition_pairwise_ne_radical
 
 ---

--- a/_thm/Q1752621.md
+++ b/_thm/Q1752621.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q1752621
+  identifiers:
+  - QuadraticForm.equivalent_one_zero_neg_one_weighted_sum_squared
 
 ---

--- a/_thm/Q1766814.md
+++ b/_thm/Q1766814.md
@@ -11,8 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q1766814
   authors:
   - Mario Carneiro
+  identifiers:
+  - Nat.Partrec.Code.smn
   date: 2018
-  comment: This theorem is trivial when using Mathlib's computability definition,
-    but this definition is equivalent to the usual one, as shown in `Nat.Partrec'.part_iff`.
 
 ---

--- a/_thm/Q179208.md
+++ b/_thm/Q179208.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q179208
   authors:
   - Eric Wieser
+  identifiers:
+  - Equiv.Perm.subgroupOfMulAction
   date: 2021
 
 ---

--- a/_thm/Q180345.md
+++ b/_thm/Q180345.md
@@ -9,5 +9,8 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q180345
+  identifiers:
+  - num_dvd_of_is_root
+  - den_dvd_of_is_root
 
 ---

--- a/_thm/Q180345X.md
+++ b/_thm/Q180345X.md
@@ -10,5 +10,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q180345X
+  identifiers:
+  - isInteger_of_is_root_of_monic
 
 ---

--- a/_thm/Q1816952.md
+++ b/_thm/Q1816952.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q1816952
+  identifiers:
+  - CategoryTheory.finrank_endomorphism_simple_eq_one
 
 ---

--- a/_thm/Q18206266.md
+++ b/_thm/Q18206266.md
@@ -11,5 +11,7 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q18206266
   authors:
   - Aaron Anderson
+  identifiers:
+  - Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect
 
 ---

--- a/_thm/Q182505.md
+++ b/_thm/Q182505.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q182505
   authors:
   - Rishikesh Vaishnav
+  identifiers:
+  - ProbabilityTheory.cond_eq_inv_mul_cond_mul
   date: 2022
 
 ---

--- a/_thm/Q188295.md
+++ b/_thm/Q188295.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q188295
   authors:
   - Aaron Anderson
+  identifiers:
+  - ZMod.pow_card_sub_one_eq_one
   date: 2020
 
 ---

--- a/_thm/Q189136.md
+++ b/_thm/Q189136.md
@@ -11,6 +11,9 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q189136
   authors:
   - Yury G. Kudryashov
+  identifiers:
+  - exists_deriv_eq_slope
+  - exists_ratio_deriv_eq_ratio_slope
   date: 2019
 
 ---

--- a/_thm/Q1893717.md
+++ b/_thm/Q1893717.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q1893717
+  identifiers:
+  - ComputablePred.rice
 
 ---

--- a/_thm/Q190556.md
+++ b/_thm/Q190556.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q190556
   authors:
   - Abhimanyu Pallavi Sudhir
+  identifiers:
+  - Complex.cos_add_sin_mul_I_pow
   date: 2019
 
 ---

--- a/_thm/Q191693.md
+++ b/_thm/Q191693.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q191693
   authors:
   - Kexing Ying
+  identifiers:
+  - MeasureTheory.Measure.haveLebesgueDecomposition_of_sigmaFinite
   date: 2021
 
 ---

--- a/_thm/Q192760.md
+++ b/_thm/Q192760.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q192760
   authors:
   - Chris Hughes
+  identifiers:
+  - Complex.isAlgClosed
   date: 2019
 
 ---

--- a/_thm/Q193286.md
+++ b/_thm/Q193286.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q193286
   authors:
   - Yury G. Kudryashov
+  identifiers:
+  - exists_deriv_eq_zero
   date: 2019
 
 ---

--- a/_thm/Q1933521.md
+++ b/_thm/Q1933521.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q1933521
   authors:
   - Mario Carneiro
+  identifiers:
+  - Nat.Partrec.Code.fixed_point₂
   date: 2018
 
 ---

--- a/_thm/Q193878.md
+++ b/_thm/Q193878.md
@@ -10,5 +10,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q193878
+  identifiers:
+  - Ideal.quotientInfRingEquivPiQuotient
 
 ---

--- a/_thm/Q2027347.md
+++ b/_thm/Q2027347.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q2027347
   authors:
   - Kexing Ying, Rémy Degenne
+  identifiers:
+  - MeasureTheory.submartingale_iff_expected_stoppedValue_mono
   date: 2022
 
 ---

--- a/_thm/Q203565.md
+++ b/_thm/Q203565.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q203565
   authors:
   - Jeoff Lee
+  identifiers:
+  - Theorems100.cubic_eq_zero_iff
   date: 2022
 
 ---

--- a/_thm/Q2093886.md
+++ b/_thm/Q2093886.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q2093886
+  identifiers:
+  - Field.exists_primitive_element
 
 ---

--- a/_thm/Q220680.md
+++ b/_thm/Q220680.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q220680
+  identifiers:
+  - ContractingWith.exists_fixedPoint
 
 ---

--- a/_thm/Q2226786.md
+++ b/_thm/Q2226786.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q2226786
   authors:
   - Bhavik Mehta, Alena Gusakov, Yaël Dillies
+  identifiers:
+  - IsAntichain.sperner
   date: 2022
 
 ---

--- a/_thm/Q2226800.md
+++ b/_thm/Q2226800.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q2226800
   authors:
   - Thomas Browning
+  identifiers:
+  - Subgroup.exists_left_complement'_of_coprime
   date: 2021
 
 ---

--- a/_thm/Q2253746.md
+++ b/_thm/Q2253746.md
@@ -12,5 +12,7 @@ lean:
   authors:
   - Bhavik Mehta
   - Kexing Ying
+  identifiers:
+  - Ballot.ballot_problem
 
 ---

--- a/_thm/Q2275191.md
+++ b/_thm/Q2275191.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q2275191
   authors:
   - Sébastien Gouëzel
+  identifiers:
+  - VitaliFamily.ae_tendsto_lintegral_div
   date: 2021
 
 ---

--- a/_thm/Q22952648.md
+++ b/_thm/Q22952648.md
@@ -11,5 +11,7 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q22952648
   authors:
   - Floris van Doorn
+  identifiers:
+  - Cardinal.not_countable_real
 
 ---

--- a/_thm/Q245098.md
+++ b/_thm/Q245098.md
@@ -12,5 +12,7 @@ lean:
   authors:
   - Rob Lewis
   - Chris Hughes
+  identifiers:
+  - intermediate_value_Icc
 
 ---

--- a/_thm/Q2471737.md
+++ b/_thm/Q2471737.md
@@ -1,5 +1,5 @@
 ---
-# Carathéodory's theorem
+# Carathéodory's theorem (convex hull)
 
 wikidata: Q2471737
 msc_classification: '52'
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q2471737
+  identifiers:
+  - convexHull_eq_union
 
 ---

--- a/_thm/Q2525646.md
+++ b/_thm/Q2525646.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q2525646
+  identifiers:
+  - CompositionSeries.jordan_holder
 
 ---

--- a/_thm/Q253214.md
+++ b/_thm/Q253214.md
@@ -9,5 +9,8 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q253214
+  identifiers:
+  - Metric.isCompact_iff_isClosed_bounded
+  - FiniteDimensional.proper
 
 ---

--- a/_thm/Q258374.md
+++ b/_thm/Q258374.md
@@ -1,5 +1,5 @@
 ---
-# Carathéodory's theorem
+# Carathéodory's theorem (measure theory)
 
 wikidata: Q258374
 msc_classification: '28'
@@ -9,6 +9,8 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q258374
+  identifiers:
+  - MeasureTheory.OuterMeasure.caratheodory
   comment: Hard to say what exactly is meant.
 
 ---

--- a/_thm/Q26708.md
+++ b/_thm/Q26708.md
@@ -11,5 +11,7 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q26708
   authors:
   - Chris Hughes
+  identifiers:
+  - add_pow
 
 ---

--- a/_thm/Q276082.md
+++ b/_thm/Q276082.md
@@ -11,5 +11,7 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q276082
   authors:
   - Chris Hughes
+  identifiers:
+  - ZMod.wilsons_lemma
 
 ---

--- a/_thm/Q288465.md
+++ b/_thm/Q288465.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q288465
+  identifiers:
+  - MulAction.orbitEquivQuotientStabilizer
 
 ---

--- a/_thm/Q2919401.md
+++ b/_thm/Q2919401.md
@@ -13,6 +13,8 @@ lean:
   - David Kurniadi Angdinata, Fabrizio Barroero, Laura Capuano, Nirvana Coppola, María
     Inés de Frutos-Fernández, Sam van Gool, Silvain Rideau-Kikuchi, Amos Turchet,
     Francesco Veneziano
+  identifiers:
+  - Rat.AbsoluteValue.equiv_real_or_padic
   date: 2024
 
 ---

--- a/_thm/Q303402.md
+++ b/_thm/Q303402.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q303402
+  identifiers:
+  - LinearMap.rank_range_add_rank_ker
 
 ---

--- a/_thm/Q318767.md
+++ b/_thm/Q318767.md
@@ -11,5 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q318767
   authors:
   - Jeremy Tan
+  identifiers:
+  - Complex.tendsto_tsum_powerSeries_nhdsWithin_stolzCone
+  - Real.tendsto_tsum_powerSeries_nhdsWithin_lt
 
 ---

--- a/_thm/Q3229352.md
+++ b/_thm/Q3229352.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q3229352
   authors:
   - Sébastien Gouëzel
+  identifiers:
+  - Vitali.exists_disjoint_covering_ae
   date: 2021
 
 ---

--- a/_thm/Q3527102.md
+++ b/_thm/Q3527102.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q3527102
   authors:
   - Bhavik Mehta, Yaël Dillies
+  identifiers:
+  - Finset.kruskal_katona
   date: 2020
 
 ---

--- a/_thm/Q3527118.md
+++ b/_thm/Q3527118.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q3527118
+  identifiers:
+  - PadicInt.hasSum_mahler
 
 ---

--- a/_thm/Q3527189.md
+++ b/_thm/Q3527189.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q3527189
+  identifiers:
+  - QuotientGroup.quotientQuotientEquivQuotient
 
 ---

--- a/_thm/Q3527205.md
+++ b/_thm/Q3527205.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q3527205
+  identifiers:
+  - mk_eq_mk_of_basis
 
 ---

--- a/_thm/Q3527215.md
+++ b/_thm/Q3527215.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q3527215
   authors:
   - Zhouhang Zhou
+  identifiers:
+  - exists_norm_eq_iInf_of_complete_convex
   date: 2019
 
 ---

--- a/_thm/Q3527250.md
+++ b/_thm/Q3527250.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q3527250
   authors:
   - Xavier Généreux
+  identifiers:
+  - Complex.HadamardThreeLines.norm_le_interpStrip_of_mem_verticalClosedStrip
   date: 2023
 
 ---

--- a/_thm/Q3527263.md
+++ b/_thm/Q3527263.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q3527263
   authors:
   - Ira Fesefeldt
+  identifiers:
+  - fixedPoints.lfp_eq_sSup_iterate
   date: 2024
 
 ---

--- a/_thm/Q3984053.md
+++ b/_thm/Q3984053.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q3984053
   authors:
   - Sébastien Gouëzel
+  identifiers:
+  - Continuous.fourier_inversion
   date: 2024
 
 ---

--- a/_thm/Q420714.md
+++ b/_thm/Q420714.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q420714
+  identifiers:
+  - AkraBazziRecurrence.isBigO_asympBound
 
 ---

--- a/_thm/Q422187.md
+++ b/_thm/Q422187.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q422187
   authors:
   - Chris Wong
+  identifiers:
+  - Language.isRegular_iff_finite_range_leftQuotient
   date: 2024-03-24
 
 ---

--- a/_thm/Q4378868.md
+++ b/_thm/Q4378868.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q4378868
   authors:
   - Yury G. Kudryashov
+  identifiers:
+  - PhragmenLindelof.horizontal_strip
   date: 2022
 
 ---

--- a/_thm/Q459547.md
+++ b/_thm/Q459547.md
@@ -11,5 +11,7 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q459547
   authors:
   - Manuel Candales
+  identifiers:
+  - EuclideanGeometry.mul_dist_add_mul_dist_eq_mul_dist_of_cospherical
 
 ---

--- a/_thm/Q468391.md
+++ b/_thm/Q468391.md
@@ -9,5 +9,8 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q468391
+  identifiers:
+  - tendsto_subseq_of_frequently_bounded
+  - tendsto_subseq_of_bounded
 
 ---

--- a/_thm/Q4695203.md
+++ b/_thm/Q4695203.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q4695203
   authors:
   - Yaël Dillies
+  identifiers:
+  - four_functions_theorem
   date: 2023
 
 ---

--- a/_thm/Q470877.md
+++ b/_thm/Q470877.md
@@ -14,5 +14,7 @@ lean:
   - Fabian Kruse
   - Nikolas Kuhn
   - Heather Macbeth
+  identifiers:
+  - Stirling.tendsto_stirlingSeq_sqrt_pi
 
 ---

--- a/_thm/Q472883.md
+++ b/_thm/Q472883.md
@@ -12,5 +12,8 @@ lean:
   authors:
   - Chris Hughes (first)
   - Michael Stoll (second)
+  identifiers:
+  - legendreSym.quadratic_reciprocity
+  - jacobiSym.quadratic_reciprocity
 
 ---

--- a/_thm/Q474881.md
+++ b/_thm/Q474881.md
@@ -12,5 +12,7 @@ lean:
   authors:
   - Johannes Hölzl
   - Mario Carneiro
+  identifiers:
+  - Function.cantor_surjective
 
 ---

--- a/_thm/Q476776.md
+++ b/_thm/Q476776.md
@@ -11,5 +11,7 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q476776
   authors:
   - Thomas Zhu
+  identifiers:
+  - Theorems100.quartic_eq_zero_iff
 
 ---

--- a/_thm/Q4830725.md
+++ b/_thm/Q4830725.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q4830725
   authors:
   - Chris Hughes
+  identifiers:
+  - ax_grothendieck_zeroLocus
   date: 2023
 
 ---

--- a/_thm/Q4878586.md
+++ b/_thm/Q4878586.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q4878586
   authors:
   - Bhavik Mehta
+  identifiers:
+  - CategoryTheory.Monad.monadicOfCreatesGSplitCoequalizers
   date: 2020
 
 ---

--- a/_thm/Q505798.md
+++ b/_thm/Q505798.md
@@ -1,5 +1,5 @@
 ---
-# Lagrange's theorem
+# Lagrange's theorem (group theory)
 
 wikidata: Q505798
 msc_classification: '20'
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q505798
+  identifiers:
+  - Subgroup.card_subgroup_dvd_card
 
 ---

--- a/_thm/Q5171652.md
+++ b/_thm/Q5171652.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q5171652
   authors:
   - Yaël Dillies, Bhavik Mehta
+  identifiers:
+  - corners_theorem_nat
   date: 2022
 
 ---

--- a/_thm/Q530152.md
+++ b/_thm/Q530152.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q530152
+  identifiers:
+  - IsPicardLindelof.exists_forall_hasDerivWithinAt_Icc_eq
 
 ---

--- a/_thm/Q536640.md
+++ b/_thm/Q536640.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q536640
+  identifiers:
+  - Finset.all_card_le_biUnion_card_iff_exists_injective
 
 ---

--- a/_thm/Q537618.md
+++ b/_thm/Q537618.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q537618
+  identifiers:
+  - WeakDual.isCompact_polar
 
 ---

--- a/_thm/Q5437947.md
+++ b/_thm/Q5437947.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q5437947
+  identifiers:
+  - MeasureTheory.lintegral_liminf_le
 
 ---

--- a/_thm/Q550402.md
+++ b/_thm/Q550402.md
@@ -11,5 +11,7 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q550402
   authors:
   - David Loeffler, Michael Stoll
+  identifiers:
+  - Nat.setOf_prime_and_eq_mod_infinite
 
 ---

--- a/_thm/Q5504427.md
+++ b/_thm/Q5504427.md
@@ -13,5 +13,7 @@ lean:
   - Aaron Anderson
   - Jalex Stark
   - Kyle Miller
+  identifiers:
+  - Theorems100.friendship_theorem
 
 ---

--- a/_thm/Q570779.md
+++ b/_thm/Q570779.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q570779
+  identifiers:
+  - Multiset.prod_X_add_C_eq_sum_esymm
 
 ---

--- a/_thm/Q576478.md
+++ b/_thm/Q576478.md
@@ -1,5 +1,5 @@
 ---
-# Liouville's theorem
+# Liouville's theorem (complex analysis)
 
 wikidata: Q576478
 msc_classification: '30'
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q576478
+  identifiers:
+  - Differentiable.apply_eq_apply_of_bounded
 
 ---

--- a/_thm/Q595466.md
+++ b/_thm/Q595466.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q595466
   authors:
   - Jireh Loreaux
+  identifiers:
+  - Monotone.tendstoLocallyUniformly_of_forall_tendsto
   date: 2024
 
 ---

--- a/_thm/Q609612.md
+++ b/_thm/Q609612.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q609612
   authors:
   - Kenny Lau
+  identifiers:
+  - fixedPoints.completeLattice
   date: 2018
 
 ---

--- a/_thm/Q619985.md
+++ b/_thm/Q619985.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q619985
+  identifiers:
+  - Finset.sum_pow_eq_sum_piAntidiag_of_commute
 
 ---

--- a/_thm/Q632546.md
+++ b/_thm/Q632546.md
@@ -12,5 +12,7 @@ lean:
   authors:
   - Bolton Bailey
   - Patrick Stevens
+  identifiers:
+  - Nat.bertrand
 
 ---

--- a/_thm/Q642620.md
+++ b/_thm/Q642620.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q642620
   authors:
   - Yaël Dillies
+  identifiers:
+  - closure_convexHull_extremePoints
   date: 2022
 
 ---

--- a/_thm/Q656645.md
+++ b/_thm/Q656645.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q656645
   authors:
   - Kenny Lau
+  identifiers:
+  - Polynomial.isNoetherianRing
   date: 2019
 
 ---

--- a/_thm/Q656772.md
+++ b/_thm/Q656772.md
@@ -11,5 +11,7 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q656772
   authors:
   - Kim Morrison
+  identifiers:
+  - Matrix.aeval_self_charpoly
 
 ---

--- a/_thm/Q657482.md
+++ b/_thm/Q657482.md
@@ -11,5 +11,7 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q657482
   authors:
   - Thomas Browning
+  identifiers:
+  - AbelRuffini.exists_not_solvable_by_rad
 
 ---

--- a/_thm/Q670235.md
+++ b/_thm/Q670235.md
@@ -11,6 +11,12 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q670235
   authors:
   - Chris Hughes
+  identifiers:
+  - Nat.primeFactorsList_unique
+  - Int.euclideanDomain
+  - EuclideanDomain.to_principal_ideal_domain
+  - UniqueFactorizationMonoid
+  - UniqueFactorizationMonoid.factors_unique
   comment: it also has a generalized version, by showing that every Euclidean domain
     is a unique factorization domain, and showing that the integers form a Euclidean
     domain.

--- a/_thm/Q6813106.md
+++ b/_thm/Q6813106.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q6813106
+  identifiers:
+  - mellin_inversion
 
 ---

--- a/_thm/Q716171.md
+++ b/_thm/Q716171.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q716171
   authors:
   - Yaël Dillies
+  identifiers:
+  - ZMod.erdos_ginzburg_ziv
   date: 2023
 
 ---

--- a/_thm/Q718875.md
+++ b/_thm/Q718875.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q718875
   authors:
   - Bhavik Mehta, Yaël Dillies
+  identifiers:
+  - Finset.erdos_ko_rado
   date: 2020
 
 ---

--- a/_thm/Q720469.md
+++ b/_thm/Q720469.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q720469
   authors:
   - Johan Commelin
+  identifiers:
+  - char_dvd_card_solutions_of_sum_lt
   date: 2019
 
 ---

--- a/_thm/Q7432915.md
+++ b/_thm/Q7432915.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q7432915
+  identifiers:
+  - MeasurableEmbedding.schroederBernstein
 
 ---

--- a/_thm/Q7433182.md
+++ b/_thm/Q7433182.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q7433182
   authors:
   - Bolton Bailey, Yaël Dillies
+  identifiers:
+  - MvPolynomial.schwartz_zippel_sup_sum
   date: 2023
 
 ---

--- a/_thm/Q752375.md
+++ b/_thm/Q752375.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q752375
   authors:
   - Sébastien Gouëzel
+  identifiers:
+  - IsCompact.exists_isMinOn
   date: 2018
 
 ---

--- a/_thm/Q756946.md
+++ b/_thm/Q756946.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q756946
   authors:
   - Chris Hughes
+  identifiers:
+  - Nat.sum_four_squares
   date: 2019
 
 ---

--- a/_thm/Q764287.md
+++ b/_thm/Q764287.md
@@ -11,5 +11,7 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q764287
   authors:
   - David Wärn
+  identifiers:
+  - Combinatorics.exists_mono_homothetic_copy
 
 ---

--- a/_thm/Q765987.md
+++ b/_thm/Q765987.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q765987
+  identifiers:
+  - CompactSpace.uniformContinuous_of_continuous
 
 ---

--- a/_thm/Q776578.md
+++ b/_thm/Q776578.md
@@ -10,5 +10,7 @@ lean:
 - status: statement
   library: L
   url: https://leanprover-community.github.io/1000.html#Q776578
+  identifiers:
+  - isSemisimpleRing_iff_pi_matrix_divisionRing
 
 ---

--- a/_thm/Q7820874.md
+++ b/_thm/Q7820874.md
@@ -5,9 +5,5 @@ wikidata: Q7820874
 msc_classification: '46'
 wikipedia_links:
 - '[[Tonelli''s theorem (functional analysis)|Tonelli''s theorem]]'
-lean:
-- status: formalized
-  library: L
-  url: https://leanprover-community.github.io/1000.html#Q7820874
 
 ---

--- a/_thm/Q7888360.md
+++ b/_thm/Q7888360.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q7888360
   authors:
   - Pierre-Alexandre Bazin
+  identifiers:
+  - Module.equiv_free_prod_directSum
   date: 2022
 
 ---

--- a/_thm/Q810431.md
+++ b/_thm/Q810431.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q810431
   authors:
   - David Loeffler
+  identifiers:
+  - hasSum_zeta_two
   date: 2022
 
 ---

--- a/_thm/Q834025.md
+++ b/_thm/Q834025.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q834025
   authors:
   - Yury Kudryashov
+  identifiers:
+  - Complex.circleIntegral_div_sub_of_differentiable_on_off_countable
   date: 2021
 
 ---

--- a/_thm/Q842953.md
+++ b/_thm/Q842953.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q842953
   authors:
   - Oliver Nash
+  identifiers:
+  - Besicovitch.ae_tendsto_measure_inter_div
   date: 2022
 
 ---

--- a/_thm/Q848375.md
+++ b/_thm/Q848375.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q848375
+  identifiers:
+  - ImplicitFunctionData.implicitFunction
 
 ---

--- a/_thm/Q853067.md
+++ b/_thm/Q853067.md
@@ -11,6 +11,9 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q853067
   authors:
   - Mario Carneiro (first), Michael Stoll (second)
+  identifiers:
+  - Pell.eq_pell
+  - Pell.exists_of_not_isSquare
   comment: In `pell.eq_pell`, `d` is defined to be `a*a - 1` for an arbitrary `a >
     1`.
 

--- a/_thm/Q866116.md
+++ b/_thm/Q866116.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q866116
+  identifiers:
+  - exists_extension_norm_eq
 
 ---

--- a/_thm/Q914517.md
+++ b/_thm/Q914517.md
@@ -11,5 +11,7 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q914517
   authors:
   - Chris Hughes
+  identifiers:
+  - Nat.Prime.sq_add_sq
 
 ---

--- a/_thm/Q931001.md
+++ b/_thm/Q931001.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q931001
+  identifiers:
+  - HasStrictFDerivAt.to_localInverse
 
 ---

--- a/_thm/Q939927.md
+++ b/_thm/Q939927.md
@@ -12,6 +12,8 @@ lean:
   authors:
   - Scott Morrison
   - Heather Macbeth
+  identifiers:
+  - ContinuousMap.subalgebra_topologicalClosure_eq_top_of_separatesPoints
   date: 2021-05-01
 
 ---

--- a/_thm/Q943246.md
+++ b/_thm/Q943246.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q943246
+  identifiers:
+  - littleWedderburn
 
 ---

--- a/_thm/Q944297.md
+++ b/_thm/Q944297.md
@@ -11,6 +11,8 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q944297
   authors:
   - Sébastien Gouëzel
+  identifiers:
+  - ContinuousLinearMap.isOpenMap
   date: 2019
 
 ---

--- a/_thm/Q967972.md
+++ b/_thm/Q967972.md
@@ -1,5 +1,5 @@
 ---
-# Open mapping theorem
+# Open mapping theorem (complex analysis)
 
 wikidata: Q967972
 msc_classification: '30'
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q967972
+  identifiers:
+  - AnalyticOnNhd.is_constant_or_isOpen
 
 ---

--- a/_thm/Q976607.md
+++ b/_thm/Q976607.md
@@ -11,5 +11,7 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q976607
   authors:
   - Bhavik Mehta
+  identifiers:
+  - Theorems100.erdos_szekeres
 
 ---

--- a/_thm/Q9993851.md
+++ b/_thm/Q9993851.md
@@ -9,5 +9,7 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q9993851
+  identifiers:
+  - IsCoercive.continuousLinearEquivOfBilin
 
 ---

--- a/sync_mathlib_data.py
+++ b/sync_mathlib_data.py
@@ -236,12 +236,13 @@ def _write_entry_for_downstream(entry: TheoremEntry) -> str:
     key = entry.wikidata + (entry.id_suffix or "")
     form = entry.formalisations[ProofAssistant.Lean]
     if form:
-        # We process the data fields in README order, for prettier output.
+        # We process the data fields in the order of mathlib's yaml file, for prettier output.
         # If there are several formalisations, we prioritise mathlib and stdlib
         # formalisations over external projects.
         # If there are still several, we pick the first in the theorem file.
         if len(form) > 1:
             print(f"warning: there are several formalisations for theorem {key}, skipping all but the first one")
+
         stdlib_formalisations = [f for f in form if f.library == Library.StandardLibrary]
         mathlib_formalisations = [f for f in form if f.library == Library.MainLibrary]
         if stdlib_formalisations or mathlib_formalisations:
@@ -275,16 +276,18 @@ def _write_entry_for_downstream(entry: TheoremEntry) -> str:
             first = form[0]
             assert first.library == Library.External  # internal consistency check
             # We don't mentional external formalisations of just the statement in mathlib's file.
-            # NB: this will overwrite an "interesting" external URL with the upstream one.
+            # NB: the following would overwrite an "interesting" external URL with the upstream one.
             # We cannot really help that; this is another change in the generated 1000.yaml file
             # that should not be committed downstream.
-            if first.status == FormalizationStatus.FullProof:
-                inner["url"] = first.url
+            # Instead, we choose to do nothing; that is one fewer change to ignore.
+            # if first.status == FormalizationStatus.FullProof:
+            #     inner["url"] = first.url
+
+        # Add additional metadata, so no information is lost in the generated yaml file.
         if first.authors:
             # NB: this is different from the 100 theorems project
             # 100 theorems names the field 'author'; this project uses 'authors'
             inner["authors"] = " and ".join(first.authors)
-        # Add additional metadata, so no information is lost in the generated yaml file.
         if first.date:
             inner['date'] = first.date
         if first.comment:

--- a/sync_mathlib_data.py
+++ b/sync_mathlib_data.py
@@ -395,6 +395,7 @@ def update_data_from_downstream_yaml(input_file: str) -> None:
                         if not (new_entry_typed.url, upstream_entry[0].url == (None, expected)):
                             messages.append(compare(new_entry_typed.url, upstream_entry[0].url, "URL"))
                     messages.append(compare(new_entry_typed.authors, upstream_entry[0].authors, "authors"))
+                    messages.append(compare(new_entry_typed.identifiers, upstream_entry[0].identifiers, "identifiers"))
                     messages.append(compare(new_entry_typed.date, upstream_entry[0].date, "date"))
                     messages.append(compare(new_entry_typed.comment, upstream_entry[0].comment, "comment"))
                     real_msg = [msg for msg in messages if msg]
@@ -416,6 +417,8 @@ def update_data_from_downstream_yaml(input_file: str) -> None:
             }
             if new_entry_typed.authors:
                 inner["authors"] = new_entry_typed.authors
+            if new_entry_typed.identifiers:
+                inner["identifiers"] = new_entry_typed.identifiers
             if new_entry_typed.date:
                 inner["date"] = new_entry_typed.date
             if new_entry_typed.comment:

--- a/sync_mathlib_data.py
+++ b/sync_mathlib_data.py
@@ -408,11 +408,12 @@ def update_data_from_downstream_yaml(input_file: str) -> None:
                     messages.append(compare(new_entry_typed.identifiers, upstream_entry[0].identifiers, "identifiers"))
                     messages.append(compare(new_entry_typed.date, upstream_entry[0].date, "date"))
                     messages.append(compare(new_entry_typed.comment, upstream_entry[0].comment, "comment"))
-                    real_msg = [msg for msg in messages if msg]
-                    if real_msg:
+                    real_messages = [msg for msg in messages if msg]
+                    if real_messages:
                         overwrite = True
                         print(f"info: formalizations entries for {id_with_suffix} are different!")
-                        print(msg)
+                        for m in real_messages:
+                            print(m)
                         print(f"debug: overwriting file {upstream_file} with downstream data")
                 else:
                     print(f"info: formalizations for theorem {id_with_suffix} have the same data")

--- a/sync_mathlib_data.py
+++ b/sync_mathlib_data.py
@@ -368,6 +368,10 @@ def update_data_from_downstream_yaml(input_file: str) -> None:
 
         # Read the _thm data file and compare data on Lean formalisations.
         upstream_file = os.path.join(THMS_DIR, f"{id_with_suffix}.md")
+        if id_with_suffix == 'Q513028':
+            # TODO: remove this entry once the upstream theorems list gets re-generated
+            print(f"warning: skipping downstream theorem Q513028 as the file is not yet present upstream", file=sys.stderr)
+            continue
         with open(upstream_file, 'r') as f:
             contents = f.readlines()
             # The full contents of the upstream markdown file: we preserve anything

--- a/sync_mathlib_data.py
+++ b/sync_mathlib_data.py
@@ -381,11 +381,11 @@ def update_data_from_downstream_yaml(input_file: str) -> None:
 
         overwrite = False
         if new_entry_typed and (not upstream_entry):
-            print(f"update: found a new Lean formalisation of {id_with_suffix} in 1000.yaml, "
+            print(f"info: found a new Lean formalisation of {id_with_suffix} in 1000.yaml, "
               "trying to update upstream file now")
             overwrite = True
         elif (new_entry_typed is None) and upstream_entry:
-            print(f"update: Lean formalisation of {id_with_suffix} is noted upstream, but not downstream!")
+            print(f"info: Lean formalisation of {id_with_suffix} is noted upstream, but not downstream!")
         elif new_entry_typed and upstream_entry:
             if len(upstream_entry) > 1:
                 print(f"theorem {id_with_suffix} has one Lean formalization downstream, but {len(upstream_entry)} upstream!")


### PR DESCRIPTION
This PR accompanies #17: we
- allow, add and recognise the `identifiers` field when updating in either direction,
- change the generated downstream file slightly, to omit the auto-generated URLs to external projects (committing this in mathlib would lead to losing data),
- add an exception for Bézout's theorem, which was added downstream (but is not yet present in this repository),
- tweak the script's error messages and debugging output slightly.
