### PR TITLE
Make rows hyperlinkable

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,21 @@ The entries of this list are extracted from Wikipedia's [List of Theorems](https
 We do not accept entries that are not part of that list.
 We will (semiregularly) update the list to match the Wikipedia list. Please do not vandalize Wikipedia to try to add nonsensical entries to the list.
 
+## Linking to the list
+
+You can link to a theorem entry in the 1000+ theorems list by using its Wikidata
+identifier. To work around the pagination feature of the website, although this
+is a temporary solution, set the GET parameter `length` to `-1`. This tells the
+website to display the entire list without pagination. For example, to link to
+Zeckendorf's theorem, find its Wikidata identifier, in this case `Q1188392`.
+Then the link into the list of formalized theorems is
+
+- [`https://1000-plus.github.io/?length=-1#Q1188392`](https://1000-plus.github.io/?length=-1#Q1188392),
+
+and the link into the list of all theorems is
+
+- [`https://1000-plus.github.io/all?length=-1#Q1188392`](https://1000-plus.github.io/all?length=-1#Q1188392).
+
 ## Contributing
 
 We welcome contributions! Please open a PR with additions or corrections!
@@ -33,4 +48,3 @@ For each formalization in each proof assistant, we record the following informat
 * `authors`:  list of authors of the formalisation; optional
 * `date`:  (optional). Format: `YYYY`, `YYYY-MM` or `YYYY-MM-DD`
 * `comment`: (optional)
-

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -16,20 +16,29 @@
 <link rel="stylesheet" href="//cdn.datatables.net/buttons/3.1.1/css/buttons.dataTables.min.css">
 <script src="//cdn.datatables.net/buttons/3.1.1/js/dataTables.buttons.min.js"></script>
 
-
 <script>
     $(document).ready(function () {
+        // Extract the 'length' parameter from the URL query string, if present.
+        const urlParams = new URLSearchParams(window.location.search);
+        const lengthParam = urlParams.get('length');
+        const pageLength = lengthParam ? parseInt(lengthParam, 10) : null;
+
         let toolbar = document.createElement('div');
         toolbar.innerHTML = '<b>Custom tool bar! Text/images etc.</b>';
         let tables = $('table.datatable');
-        for (t of tables) {
-            dt = new DataTable(t, {
+        for (let t of tables) {
+            let options = {
                 "order": $(t).data('order-columns').map(n => [n, 'asc']),
                 lengthMenu: [
                     [100, 500, -1],
                     [100, 500, 'All']
                 ],
-            });
+            };
+            // If a valid pageLength was provided via GET, use it.
+            if (pageLength) {
+                options.pageLength = pageLength;
+            }
+            let dt = new DataTable(t, options);
             dt.columns().every(function () {
                 if ($(this.header()).data('hide-column')) {
                     this.visible(false);

--- a/all.md
+++ b/all.md
@@ -23,7 +23,7 @@ layout: plain
     <tbody>
         {% assign sorted = site.thm | sort: "wikidata" %}
         {% for t in sorted %}
-            <tr>
+            <tr id="{{ t.wikidata }}">
                 <td class="dt-body-center"><span title="{{ site.data.msc[t.msc_classification] }}">{{ t.msc_classification }}</span></td>
                 <td>
                     {% assign wl = t.wikipedia_links.first %}

--- a/all.md
+++ b/all.md
@@ -35,7 +35,7 @@ layout: plain
                         {% assign wlabel = wl | remove: '[[' | remove: ']]' %}
                         {% assign wurl = wlabel %}
                     {% endif %}
-                    <a href="https://en.wikipedia.org/wiki/{{ wurl }}">{{ wlabel }}</a>
+                    <a href="https://en.wikipedia.org/wiki/{{ wurl }}" title="Wikidata ID {{ t.wikidata }}">{{ wlabel }}</a>
                 </td>
                 <td class="dt-body-center"></td>
                 <td class="dt-body-center"></td>

--- a/index.md
+++ b/index.md
@@ -24,7 +24,7 @@ layout: plain
         {% assign sorted = site.thm | sort: "wikidata" %}
         {% for t in sorted %}
             {% if t.isabelle or t.hol_light or t.coq or t.lean or t.metamath or t.mizar %}
-            <tr>
+            <tr id="{{ t.wikidata }}">
                 <td class="dt-body-center"><span title="{{ site.data.msc[t.msc_classification] }}">{{ t.msc_classification }}</span></td>
                 <td>
                     {% assign wl = t.wikipedia_links.first %}

--- a/index.md
+++ b/index.md
@@ -36,7 +36,7 @@ layout: plain
                         {% assign wlabel = wl | remove: '[[' | remove: ']]' %}
                         {% assign wurl = wlabel %}
                     {% endif %}
-                    <a href="https://en.wikipedia.org/wiki/{{ wurl }}">{{ wlabel }}</a>
+                    <a href="https://en.wikipedia.org/wiki/{{ wurl }}" title="Wikidata ID {{ t.wikidata }}">{{ wlabel }}</a>
                 </td>
                 <td class="dt-body-center"></td>
                 <td class="dt-body-center"></td>


### PR DESCRIPTION
Sets the HTML identifier of each row to its Wikidata identifier, and accepts page length as a GET parameter. This is a bit of a hacky solution, but it makes it possible to link to a specific row by using a link of the form `https://1000-plus.github.io/?length=-1#Q3527263` or `https://1000-plus.github.io/all.html?length=-1#Q3527263`.

Resolves #24.