### PR TITLE
Display formalizations in all proof assistants

### DIFF
--- a/all.md
+++ b/all.md
@@ -37,9 +37,27 @@ layout: plain
                     {% endif %}
                     <a href="https://en.wikipedia.org/wiki/{{ wurl }}">{{ wlabel }}</a>
                 </td>
-                <td class="dt-body-center"></td>
-                <td class="dt-body-center"></td>
-                <td class="dt-body-center"></td>
+                <td class="dt-body-center">
+                    {% if t.isabelle %}
+                        {% for f in t.isabelle %}
+                            <a href="{{ f.url }}" title="{{ f.authors | join: ', ' }}">{{ f.library }}</a>
+                        {% endfor %}
+                    {% endif %}
+                </td>
+                <td class="dt-body-center">
+                    {% if t.hol_light %}
+                        {% for f in t.hol_light %}
+                            <a href="{{ f.url }}" title="{{ f.authors | join: ', ' }}">{{ f.library }}</a>
+                        {% endfor %}
+                    {% endif %}
+                </td>
+                <td class="dt-body-center">
+                    {% if t.coq %}
+                        {% for f in t.coq %}
+                            <a href="{{ f.url }}" title="{{ f.authors | join: ', ' }}">{{ f.library }}</a>
+                        {% endfor %}
+                    {% endif %}
+                </td>
                 <td class="dt-body-center">
                     {% if t.lean %}
                         {% for f in t.lean %}
@@ -47,8 +65,20 @@ layout: plain
                         {% endfor %}
                     {% endif %}
                 </td>
-                <td class="dt-body-center"></td>
-                <td class="dt-body-center"></td>
+                <td class="dt-body-center">
+                    {% if t.metamath %}
+                        {% for f in t.metamath %}
+                            <a href="{{ f.url }}" title="{{ f.authors | join: ', ' }}">{{ f.library }}</a>
+                        {% endfor %}
+                    {% endif %}
+                </td>
+                <td class="dt-body-center">
+                    {% if t.mizar %}
+                        {% for f in t.mizar %}
+                            <a href="{{ f.url }}" title="{{ f.authors | join: ', ' }}">{{ f.library }}</a>
+                        {% endfor %}
+                    {% endif %}
+                </td>
             </tr>
         {% endfor %}
     </tbody>

--- a/index.md
+++ b/index.md
@@ -38,9 +38,27 @@ layout: plain
                     {% endif %}
                     <a href="https://en.wikipedia.org/wiki/{{ wurl }}">{{ wlabel }}</a>
                 </td>
-                <td class="dt-body-center"></td>
-                <td class="dt-body-center"></td>
-                <td class="dt-body-center"></td>
+                <td class="dt-body-center">
+                    {% if t.isabelle %}
+                        {% for f in t.isabelle %}
+                            <a href="{{ f.url }}" title="{{ f.authors | join: ', ' }}">{{ f.library }}</a>
+                        {% endfor %}
+                    {% endif %}
+                </td>
+                <td class="dt-body-center">
+                    {% if t.hol_light %}
+                        {% for f in t.hol_light %}
+                            <a href="{{ f.url }}" title="{{ f.authors | join: ', ' }}">{{ f.library }}</a>
+                        {% endfor %}
+                    {% endif %}
+                </td>
+                <td class="dt-body-center">
+                    {% if t.coq %}
+                        {% for f in t.coq %}
+                            <a href="{{ f.url }}" title="{{ f.authors | join: ', ' }}">{{ f.library }}</a>
+                        {% endfor %}
+                    {% endif %}
+                </td>
                 <td class="dt-body-center">
                     {% if t.lean %}
                         {% for f in t.lean %}
@@ -48,8 +66,20 @@ layout: plain
                         {% endfor %}
                     {% endif %}
                 </td>
-                <td class="dt-body-center"></td>
-                <td class="dt-body-center"></td>
+                <td class="dt-body-center">
+                    {% if t.metamath %}
+                        {% for f in t.metamath %}
+                            <a href="{{ f.url }}" title="{{ f.authors | join: ', ' }}">{{ f.library }}</a>
+                        {% endfor %}
+                    {% endif %}
+                </td>
+                <td class="dt-body-center">
+                    {% if t.mizar %}
+                        {% for f in t.mizar %}
+                            <a href="{{ f.url }}" title="{{ f.authors | join: ', ' }}">{{ f.library }}</a>
+                        {% endfor %}
+                    {% endif %}
+                </td>
             </tr>
             {% endif %}
         {% endfor %}


### PR DESCRIPTION
While working on an implementation for #22, I noticed that you only display formalizations for Lean. This fixes that.
~~Note that the entries for many of the other proof assistants are wrong, they seem to be filled with test data.~~

Fixes #19