### PR TITLE
Rename Coq to Rocq

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For an example of a file with a formalization entry, see [Q208416.md](_thm/Q2084
 * `id_suffix` (optional): disambiguates an entry when two theorems have the same wikidata identifier. `X` means an extra theorem on a Wikipedia page (e.g. a generalization or special case), `A`/`B`/... means different theorems on one Wikipedia page that doesn't have a "main" theorem.
 * `msc_classification`: Our best guess of the [MSC-classification](https://msc2020.org/) of this theorem. Please PR a better suggestion!
 * `wikipedia_links`: list of exact wikipedia links to the relevant page(s). Each link has the format `[[Page name]]` or `[[Wikilink|Displayed name]]`.
-* Then zero or more entries for the formalizations in any of the supported proof assistants (`isabelle`, `hol_light`, `coq`, `lean`, `metamath`, `mizar`). Several formalization entries for one assistant are allowed.
+* Then zero or more entries for the formalizations in any of the supported proof assistants (`isabelle`, `hol_light`, `rocq` (formerly `coq`), `lean`, `metamath`, `mizar`). Several formalization entries for one assistant are allowed.
 
 For each formalization in each proof assistant, we record the following information
 

--- a/_thm/Q1033910.md
+++ b/_thm/Q1033910.md
@@ -11,10 +11,10 @@ lean:
   url: https://leanprover-community.github.io/1000.html#Q1033910
   authors:
   - Mario Carneiro
-coq:
+rocq:
 - status: formalized
   library: X
-  url: "https://github.com/coq-contribs/schroeder/blob/master/Schroeder.v"
+  url: "https://github.com/rocq-archive/schroeder/blob/master/Schroeder.v"
   authors:
   - Hugo Herbelin
 isabelle:

--- a/all.md
+++ b/all.md
@@ -52,8 +52,8 @@ layout: plain
                     {% endif %}
                 </td>
                 <td class="dt-body-center">
-                    {% if t.coq %}
-                        {% for f in t.coq %}
+                    {% if t.rocq %}
+                        {% for f in t.rocq %}
                             <a href="{{ f.url }}" title="{{ f.authors | join: ', ' }}">{{ f.library }}</a>
                         {% endfor %}
                     {% endif %}

--- a/all.md
+++ b/all.md
@@ -14,7 +14,7 @@ layout: plain
             <th>Name</th>
             <th class="dt-head-center">Isabelle</th>
             <th class="dt-head-center">HOL Light</th>
-            <th class="dt-head-center">Coq/Rocq</th>
+            <th class="dt-head-center">Rocq</th>
             <th class="dt-head-center">Lean</th>
             <th class="dt-head-center">Metamath</th>
             <th class="dt-head-center">Mizar</th>

--- a/all.md
+++ b/all.md
@@ -14,7 +14,7 @@ layout: plain
             <th>Name</th>
             <th class="dt-head-center">Isabelle</th>
             <th class="dt-head-center">HOL Light</th>
-            <th class="dt-head-center">Rocq</th>
+            <th class="dt-head-center">Coq/Rocq</th>
             <th class="dt-head-center">Lean</th>
             <th class="dt-head-center">Metamath</th>
             <th class="dt-head-center">Mizar</th>

--- a/all.md
+++ b/all.md
@@ -14,7 +14,7 @@ layout: plain
             <th>Name</th>
             <th class="dt-head-center">Isabelle</th>
             <th class="dt-head-center">HOL Light</th>
-            <th class="dt-head-center">Coq</th>
+            <th class="dt-head-center">Rocq</th>
             <th class="dt-head-center">Lean</th>
             <th class="dt-head-center">Metamath</th>
             <th class="dt-head-center">Mizar</th>

--- a/index.md
+++ b/index.md
@@ -53,8 +53,8 @@ layout: plain
                     {% endif %}
                 </td>
                 <td class="dt-body-center">
-                    {% if t.coq %}
-                        {% for f in t.coq %}
+                    {% if t.rocq %}
+                        {% for f in t.rocq %}
                             <a href="{{ f.url }}" title="{{ f.authors | join: ', ' }}">{{ f.library }}</a>
                         {% endfor %}
                     {% endif %}

--- a/index.md
+++ b/index.md
@@ -14,7 +14,7 @@ layout: plain
             <th>Name</th>
             <th class="dt-head-center">Isabelle</th>
             <th class="dt-head-center">HOL Light</th>
-            <th class="dt-head-center">Coq/Rocq</th>
+            <th class="dt-head-center">Rocq</th>
             <th class="dt-head-center">Lean</th>
             <th class="dt-head-center">Metamath</th>
             <th class="dt-head-center">Mizar</th>

--- a/index.md
+++ b/index.md
@@ -14,7 +14,7 @@ layout: plain
             <th>Name</th>
             <th class="dt-head-center">Isabelle</th>
             <th class="dt-head-center">HOL Light</th>
-            <th class="dt-head-center">Rocq</th>
+            <th class="dt-head-center">Coq/Rocq</th>
             <th class="dt-head-center">Lean</th>
             <th class="dt-head-center">Metamath</th>
             <th class="dt-head-center">Mizar</th>

--- a/index.md
+++ b/index.md
@@ -14,7 +14,7 @@ layout: plain
             <th>Name</th>
             <th class="dt-head-center">Isabelle</th>
             <th class="dt-head-center">HOL Light</th>
-            <th class="dt-head-center">Coq</th>
+            <th class="dt-head-center">Rocq</th>
             <th class="dt-head-center">Lean</th>
             <th class="dt-head-center">Metamath</th>
             <th class="dt-head-center">Mizar</th>
@@ -23,7 +23,7 @@ layout: plain
     <tbody>
         {% assign sorted = site.thm | sort: "wikidata" %}
         {% for t in sorted %}
-            {% if t.isabelle or t.hol_light or t.coq or t.lean or t.metamath or t.mizar %}
+            {% if t.isabelle or t.hol_light or t.rocq or t.lean or t.metamath or t.mizar %}
             <tr>
                 <td class="dt-body-center"><span title="{{ site.data.msc[t.msc_classification] }}">{{ t.msc_classification }}</span></td>
                 <td>

--- a/sync_mathlib_data.py
+++ b/sync_mathlib_data.py
@@ -31,7 +31,7 @@ import yaml
 class ProofAssistant(Enum):
     Isabelle = auto()
     HolLight = auto()
-    Coq = auto()
+    Rocq = auto()
     Lean = auto()
     Metamath = auto()
     Mizar = auto()
@@ -126,7 +126,7 @@ class TheoremEntryRaw:
     id_suffix: Optional[str] = None
     isabelle: Optional[List[FormalizationEntryRaw]] = None
     hol_light: Optional[List[FormalizationEntryRaw]] = None
-    coq: Optional[List[FormalizationEntryRaw]] = None
+    rocq: Optional[List[FormalizationEntryRaw]] = None
     lean: Optional[List[FormalizationEntryRaw]] = None
     metamath: Optional[List[FormalizationEntryRaw]] = None
     mizar: Optional[List[FormalizationEntryRaw]] = None
@@ -182,7 +182,7 @@ def _parse_theorem_entry(contents: List[str]) -> TheoremEntry | None:
     passthrough = {
         ProofAssistant.Isabelle: raw_thm.isabelle,
         ProofAssistant.HolLight: raw_thm.hol_light,
-        ProofAssistant.Coq: raw_thm.coq,
+        ProofAssistant.Rocq: raw_thm.rocq,
         ProofAssistant.Metamath: raw_thm.metamath,
         ProofAssistant.Mizar: raw_thm.mizar,
         ProofAssistant.Lean: raw_thm.lean,


### PR DESCRIPTION
Following the official naming change of the proof assistant, it seems appropriate to incorporate that change in this project. Now is likely the best time for such a naming change, before more data for the language is added.