### PR TITLE
Rename Sokhatsky–Weierstrass to Sokhotski–Plemelj

### DIFF
--- a/_thm/Q1543149.md
+++ b/_thm/Q1543149.md
@@ -1,8 +1,8 @@
 ---
-# Sokhatsky–Weierstrass theorem
+# Sokhotski–Plemelj theorem
 
 wikidata: Q1543149
 msc_classification: "30"
 wikipedia_links:
-  - "[[Sokhatsky–Weierstrass theorem]]"
+  - "[[Sokhotski–Plemelj theorem]]"
 ---


### PR DESCRIPTION
The updated name is the one used by https://www.wikidata.org/wiki/Q1543149, and the current link redirects to https://en.wikipedia.org/wiki/Sokhotski%E2%80%93Plemelj_theorem