### PR TITLE
Fix typo in Vantieghem's theorem title

### DIFF
--- a/_thm/Q2226807.md
+++ b/_thm/Q2226807.md
@@ -1,8 +1,8 @@
 ---
-# Vantieghems theorem
+# Vantieghem's theorem
 
 wikidata: Q2226807
 msc_classification: "11"
 wikipedia_links:
-  - "[[Vantieghems theorem]]"
+  - "[[Vantieghems theorem|Vantieghem's theorem]]"
 ---


### PR DESCRIPTION
The theorem is due to Emmanuel Vantieghem, which means the name should either be "Vantieghem's theorem" or "Vantieghem theorem". The name of the wikipedia article seems to be mistaken.