### PR TITLE
chore: update Lean formalisation data

### DIFF
--- a/_thm/Q1008566.md
+++ b/_thm/Q1008566.md
@@ -10,7 +10,8 @@ lean:
   library: L
   url: https://leanprover-community.github.io/1000.html#Q1008566
   authors:
-  - Yury Kudryashov, Aristotle AI
+  - Yury Kudryashov
+  - Aristotle AI
   identifiers:
   - Polynomial.rootSet_derivative_subset_convexHull_rootSet
   - Polynomial.eq_centerMass_of_eval_derivative_eq_zero

--- a/_thm/Q1082910.md
+++ b/_thm/Q1082910.md
@@ -12,7 +12,8 @@ lean:
   authors:
   - Bhavik Mehta
   - Aaron Anderson
+  - Weiyi Wang
   identifiers:
-  - Theorems100.partition_theorem
+  - Nat.Partition.card_odds_eq_card_distincts
 
 ---

--- a/_thm/Q1148215.md
+++ b/_thm/Q1148215.md
@@ -10,7 +10,10 @@ lean:
   library: L
   url: https://leanprover-community.github.io/1000.html#Q1148215
   authors:
-  - Markus Himmel, Jakob von Raumer, Paul Reichert, Joël Riou
+  - Markus Himmel
+  - Jakob von Raumer
+  - Paul Reichert
+  - Joël Riou
   identifiers:
   - CategoryTheory.Abelian.freyd_mitchell
 

--- a/_thm/Q1227703.md
+++ b/_thm/Q1227703.md
@@ -10,7 +10,8 @@ lean:
   library: L
   url: https://leanprover-community.github.io/1000.html#Q1227703
   authors:
-  - Michael Geißer, Michael Stoll
+  - Michael Geißer
+  - Michael Stoll
   identifiers:
   - AddCircle.exists_norm_nsmul_le
   - Real.exists_int_int_abs_mul_sub_le

--- a/_thm/Q1308502.md
+++ b/_thm/Q1308502.md
@@ -2,7 +2,16 @@
 # Church–Rosser theorem
 
 wikidata: Q1308502
-msc_classification: "03"
+msc_classification: '03'
 wikipedia_links:
-  - "[[Church–Rosser theorem]]"
+- '[[Church–Rosser theorem]]'
+lean:
+- status: formalized
+  library: X
+  url: https://leanprover-community.github.io/1000.html#Q1308502
+  authors:
+  - Chris Henson
+  - Maximiliano Onofre Martínez
+  comment: CSLib has a few variants for untyped terms, including β-, η-, and βη-reduction.
+
 ---

--- a/_thm/Q1443036.md
+++ b/_thm/Q1443036.md
@@ -2,7 +2,14 @@
 # Parseval's theorem
 
 wikidata: Q1443036
-msc_classification: "42"
+msc_classification: '42'
 wikipedia_links:
-  - "[[Parseval's theorem]]"
+- '[[Parseval''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1443036
+  identifiers:
+  - tsum_sq_fourierCoeff
+
 ---

--- a/_thm/Q1457052.md
+++ b/_thm/Q1457052.md
@@ -10,7 +10,9 @@ lean:
   library: L
   url: https://leanprover-community.github.io/1000.html#Q1457052
   authors:
-  - Mario Carneiro, Chris Hughes, Violeta Hernández
+  - Mario Carneiro
+  - Chris Hughes
+  - Violeta Hernández
   identifiers:
   - exists_wellOrder
   date: 2017

--- a/_thm/Q1457052.md
+++ b/_thm/Q1457052.md
@@ -12,9 +12,9 @@ lean:
   authors:
   - Mario Carneiro
   - Chris Hughes
-  - Violeta Hernández
+  - Violeta Hernández Palacios
   identifiers:
-  - exists_wellOrder
+  - exists_wellFoundedLT
   date: 2017
 
 ---

--- a/_thm/Q1551745.md
+++ b/_thm/Q1551745.md
@@ -2,7 +2,17 @@
 # Binomial inverse theorem
 
 wikidata: Q1551745
-msc_classification: "15"
+msc_classification: '15'
 wikipedia_links:
-  - "[[Binomial inverse theorem]]"
+- '[[Binomial inverse theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1551745
+  authors:
+  - Antoine Chambert-Loir
+  identifiers:
+  - Matrix.invOf_add_mul_mul'
+  date: 2025-11-11
+
 ---

--- a/_thm/Q1687147.md
+++ b/_thm/Q1687147.md
@@ -7,12 +7,12 @@ wikipedia_links:
 - '[[Sprague–Grundy theorem]]'
 lean:
 - status: formalized
-  library: L
+  library: X
   url: https://leanprover-community.github.io/1000.html#Q1687147
   authors:
   - Fox Thomson
-  identifiers:
-  - SetTheory.PGame.equiv_nim_grundyValue
+  - Julia Markus Himmel
+  - Violeta Hernández Palacios
   date: 2020
 
 ---

--- a/_thm/Q17098298.md
+++ b/_thm/Q17098298.md
@@ -2,7 +2,14 @@
 # Jacobson density theorem
 
 wikidata: Q17098298
-msc_classification: "13"
+msc_classification: '13'
 wikipedia_links:
-  - "[[Jacobson density theorem]]"
+- '[[Jacobson density theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q17098298
+  identifiers:
+  - jacobson_density
+
 ---

--- a/_thm/Q172298.md
+++ b/_thm/Q172298.md
@@ -10,6 +10,6 @@ lean:
   library: L
   url: https://leanprover-community.github.io/1000.html#Q172298
   identifiers:
-  - Ideal.isPrimary_decomposition_pairwise_ne_radical
+  - Submodule.isPrimary_decomposition_pairwise_ne_radical
 
 ---

--- a/_thm/Q179467.md
+++ b/_thm/Q179467.md
@@ -12,8 +12,8 @@ lean:
   authors:
   - Sébastien Gouezel
   identifiers:
-  - MeasureTheory.Integrable.fourier_inversion
-  - Continuous.fourier_inversion
+  - MeasureTheory.Integrable.fourierInv_fourier_eq
+  - Continuous.fourierInv_fourier_eq
   date: 2024
   comment: The wikipedia page is really vague; it's not clear what is meant here.
     While mathlib has some material already, there is space for more advanced results.

--- a/_thm/Q190391.md
+++ b/_thm/Q190391.md
@@ -2,7 +2,19 @@
 # Central limit theorem
 
 wikidata: Q190391
-msc_classification: "60"
+msc_classification: '60'
 wikipedia_links:
-  - "[[Central limit theorem]]"
+- '[[Central limit theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q190391
+  authors:
+  - Thomas Zhu
+  - Rémy Degenne
+  - Etienne Marion
+  identifiers:
+  - ProbabilityTheory.tendstoInDistribution_inv_sqrt_mul_sum_sub
+  date: 2026
+
 ---

--- a/_thm/Q193878.md
+++ b/_thm/Q193878.md
@@ -10,7 +10,12 @@ lean:
 - status: formalized
   library: L
   url: https://leanprover-community.github.io/1000.html#Q193878
+  authors:
+  - Kenny Lau
+  - Chris Hughes
   identifiers:
   - Ideal.quotientInfRingEquivPiQuotient
+  - ZMod.chineseRemainder
+  date: 2019, 2021
 
 ---

--- a/_thm/Q1966978.md
+++ b/_thm/Q1966978.md
@@ -2,7 +2,17 @@
 # Lévy continuity theorem
 
 wikidata: Q1966978
-msc_classification: "60"
+msc_classification: '60'
 wikipedia_links:
-  - "[[Lévy continuity theorem]]"
+- '[[Lévy continuity theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q1966978
+  authors:
+  - Rémy Degenne
+  identifiers:
+  - MeasureTheory.ProbabilityMeasure.tendsto_iff_tendsto_charFun
+  date: 2026
+
 ---

--- a/_thm/Q2027347.md
+++ b/_thm/Q2027347.md
@@ -10,7 +10,8 @@ lean:
   library: L
   url: https://leanprover-community.github.io/1000.html#Q2027347
   authors:
-  - Kexing Ying, Rémy Degenne
+  - Kexing Ying
+  - Rémy Degenne
   identifiers:
   - MeasureTheory.submartingale_iff_expected_stoppedValue_mono
   date: 2022

--- a/_thm/Q204884.md
+++ b/_thm/Q204884.md
@@ -2,7 +2,16 @@
 # Löb's theorem
 
 wikidata: Q204884
-msc_classification: "03"
+msc_classification: '03'
 wikipedia_links:
-  - "[[Löb's theorem]]"
+- '[[Löb''s theorem]]'
+lean:
+- status: formalized
+  library: X
+  url: https://leanprover-community.github.io/1000.html#Q204884
+  authors:
+  - Shogo Saito
+  - Mashu Noguchi
+  comment: See details for https://formalizedformallogic.github.io/Catalogue/Arithmetic/L___b___s-Theorem/#l___b-theorem
+
 ---

--- a/_thm/Q213603.md
+++ b/_thm/Q213603.md
@@ -2,7 +2,17 @@
 # Ceva's theorem
 
 wikidata: Q213603
-msc_classification: "51"
+msc_classification: '51'
 wikipedia_links:
-  - "[[Ceva's theorem]]"
+- '[[Ceva''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q213603
+  authors:
+  - Joseph Myers
+  identifiers:
+  - Affine.Triangle.prod_dist_div_dist_eq_one_of_mem_line_of_mem_line
+  date: 2026-01-09
+
 ---

--- a/_thm/Q2226625.md
+++ b/_thm/Q2226625.md
@@ -2,7 +2,16 @@
 # Commandino's theorem
 
 wikidata: Q2226625
-msc_classification: "51"
+msc_classification: '51'
 wikipedia_links:
-  - "[[Commandino's theorem]]"
+- '[[Commandino''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q2226625
+  authors:
+  - Chu Zheng
+  identifiers:
+  - Affine.Simplex.point_vsub_centroid_eq_smul_vsub
+
 ---

--- a/_thm/Q2226677.md
+++ b/_thm/Q2226677.md
@@ -10,7 +10,8 @@ lean:
   library: L
   url: https://leanprover-community.github.io/1000.html#Q2226677
   authors:
-  - Jireh Loreaux, Michael Stoll
+  - Jireh Loreaux
+  - Michael Stoll
   identifiers:
   - NormedRing.algEquivComplexOfComplete
   - NormedAlgebra.Complex.algEquivOfNormMul

--- a/_thm/Q2226786.md
+++ b/_thm/Q2226786.md
@@ -10,7 +10,9 @@ lean:
   library: L
   url: https://leanprover-community.github.io/1000.html#Q2226786
   authors:
-  - Bhavik Mehta, Alena Gusakov, Yaël Dillies
+  - Bhavik Mehta
+  - Alena Gusakov
+  - Yaël Dillies
   identifiers:
   - IsAntichain.sperner
   date: 2022

--- a/_thm/Q2267175.md
+++ b/_thm/Q2267175.md
@@ -2,7 +2,17 @@
 # Tangent-secant theorem
 
 wikidata: Q2267175
-msc_classification: "51"
+msc_classification: '51'
 wikipedia_links:
-  - "[[Tangent-secant theorem]]"
+- '[[Tangent-secant theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q2267175
+  authors:
+  - Li Jiale
+  identifiers:
+  - EuclideanGeometry.Sphere.dist_sq_eq_mul_dist_of_tangent_and_secant
+  date: 2025
+
 ---

--- a/_thm/Q2379132.md
+++ b/_thm/Q2379132.md
@@ -13,7 +13,7 @@ lean:
   - Ideal.exists_ideal_over_prime_of_isIntegral_of_isDomain
   - Ideal.exists_ideal_over_prime_of_isIntegral_of_isPrime
   - Algebra.HasGoingDown.iff_generalizingMap_primeSpectrumComap
-  - Algebra.HasGoingDown.of_specComap_localRingHom_surjective
+  - Algebra.HasGoingDown.of_comap_localRingHom_surjective
   date: 2025
 
 ---

--- a/_thm/Q2919401.md
+++ b/_thm/Q2919401.md
@@ -19,8 +19,10 @@ lean:
   - Silvain Rideau-Kikuchi
   - Amos Turchet
   - Francesco Veneziano
+  - Xavier Généreux
   identifiers:
   - Rat.AbsoluteValue.equiv_real_or_padic
+  - RatFunc.valuation_isEquiv_infty_or_adic
   date: 2024
 
 ---

--- a/_thm/Q2919401.md
+++ b/_thm/Q2919401.md
@@ -10,9 +10,15 @@ lean:
   library: L
   url: https://leanprover-community.github.io/1000.html#Q2919401
   authors:
-  - David Kurniadi Angdinata, Fabrizio Barroero, Laura Capuano, Nirvana Coppola, María
-    Inés de Frutos-Fernández, Sam van Gool, Silvain Rideau-Kikuchi, Amos Turchet,
-    Francesco Veneziano
+  - David Kurniadi Angdinata
+  - Fabrizio Barroero
+  - Laura Capuano
+  - Nirvana Coppola
+  - María Inés de Frutos-Fernández
+  - Sam van Gool
+  - Silvain Rideau-Kikuchi
+  - Amos Turchet
+  - Francesco Veneziano
   identifiers:
   - Rat.AbsoluteValue.equiv_real_or_padic
   date: 2024

--- a/_thm/Q3229335.md
+++ b/_thm/Q3229335.md
@@ -2,7 +2,17 @@
 # Borel–Carathéodory theorem
 
 wikidata: Q3229335
-msc_classification: "30"
+msc_classification: '30'
 wikipedia_links:
-  - "[[Borel–Carathéodory theorem]]"
+- '[[Borel–Carathéodory theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q3229335
+  authors:
+  - Maksym Radziwill
+  identifiers:
+  - Complex.borelCaratheodory
+  date: 2025
+
 ---

--- a/_thm/Q33481.md
+++ b/_thm/Q33481.md
@@ -10,7 +10,8 @@ lean:
   library: X
   url: https://leanprover-community.github.io/1000.html#Q33481
   authors:
-  - Benjamin Davidson, Andrew Souther
+  - Benjamin Davidson
+  - Andrew Souther
   date: 2021
 
 ---

--- a/_thm/Q3526996.md
+++ b/_thm/Q3526996.md
@@ -10,7 +10,8 @@ lean:
   library: X
   url: https://leanprover-community.github.io/1000.html#Q3526996
   authors:
-  - Rémy Degenne, Peter Pfaffelhuber
+  - Rémy Degenne
+  - Peter Pfaffelhuber
   date: 2023
 
 ---

--- a/_thm/Q3527102.md
+++ b/_thm/Q3527102.md
@@ -10,7 +10,8 @@ lean:
   library: L
   url: https://leanprover-community.github.io/1000.html#Q3527102
   authors:
-  - Bhavik Mehta, Yaël Dillies
+  - Bhavik Mehta
+  - Yaël Dillies
   identifiers:
   - Finset.kruskal_katona
   date: 2020

--- a/_thm/Q3527217.md
+++ b/_thm/Q3527217.md
@@ -2,7 +2,14 @@
 # M. Riesz extension theorem
 
 wikidata: Q3527217
-msc_classification: "46"
+msc_classification: '46'
 wikipedia_links:
-  - "[[M. Riesz extension theorem]]"
+- '[[M. Riesz extension theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q3527217
+  identifiers:
+  - riesz_extension
+
 ---

--- a/_thm/Q3527219.md
+++ b/_thm/Q3527219.md
@@ -2,7 +2,17 @@
 # Weierstrass preparation theorem
 
 wikidata: Q3527219
-msc_classification: "32"
+msc_classification: '32'
 wikipedia_links:
-  - "[[Weierstrass preparation theorem]]"
+- '[[Weierstrass preparation theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q3527219
+  authors:
+  - Jz Pan
+  identifiers:
+  - PowerSeries.exists_isWeierstrassFactorization
+  date: 2025
+
 ---

--- a/_thm/Q386292.md
+++ b/_thm/Q386292.md
@@ -10,7 +10,8 @@ lean:
   library: X
   url: https://leanprover-community.github.io/1000.html#Q386292
   authors:
-  - Alex Kontorovich, Terry Tao,
+  - Alex Kontorovich
+  - Terry Tao
   - the Prime Number Theorem + Project
   date: 2025
   comment: Ongoing formalisation of various versions in https://github.com/AlexKontorovich/PrimeNumberTheoremAnd

--- a/_thm/Q3984053.md
+++ b/_thm/Q3984053.md
@@ -12,7 +12,7 @@ lean:
   authors:
   - Sébastien Gouëzel
   identifiers:
-  - Continuous.fourier_inversion
+  - Continuous.fourierInv_fourier_eq
   date: 2024
 
 ---

--- a/_thm/Q5171652.md
+++ b/_thm/Q5171652.md
@@ -10,7 +10,8 @@ lean:
   library: L
   url: https://leanprover-community.github.io/1000.html#Q5171652
   authors:
-  - Yaël Dillies, Bhavik Mehta
+  - Yaël Dillies
+  - Bhavik Mehta
   identifiers:
   - corners_theorem_nat
   date: 2022

--- a/_thm/Q536640.md
+++ b/_thm/Q536640.md
@@ -10,7 +10,9 @@ lean:
   library: L
   url: https://leanprover-community.github.io/1000.html#Q536640
   authors:
-  - Alena Gusakov, Bhavik Mehta, Kyle Miller
+  - Alena Gusakov
+  - Bhavik Mehta
+  - Kyle Miller
   identifiers:
   - Finset.all_card_le_biUnion_card_iff_exists_injective
   - SimpleGraph.exists_isPerfectMatching_of_forall_ncard_le

--- a/_thm/Q5421989.md
+++ b/_thm/Q5421989.md
@@ -2,7 +2,16 @@
 # Exterior angle theorem
 
 wikidata: Q5421989
-msc_classification: "51"
+msc_classification: '51'
 wikipedia_links:
-  - "[[Exterior angle theorem]]"
+- '[[Exterior angle theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q5421989
+  authors:
+  - Wang Ying
+  identifiers:
+  - EuclideanGeometry.exterior_angle_eq_angle_add_angle
+
 ---

--- a/_thm/Q5463860.md
+++ b/_thm/Q5463860.md
@@ -2,7 +2,17 @@
 # Focal subgroup theorem
 
 wikidata: Q5463860
-msc_classification: "16"
+msc_classification: '16'
 wikipedia_links:
-  - "[[Focal subgroup theorem]]"
+- '[[Focal subgroup theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q5463860
+  authors:
+  - Boyang Hu
+  identifiers:
+  - Subgroup.commutator_inf_eq_focalSubgroup
+  date: 2026
+
 ---

--- a/_thm/Q550402.md
+++ b/_thm/Q550402.md
@@ -10,7 +10,8 @@ lean:
   library: L
   url: https://leanprover-community.github.io/1000.html#Q550402
   authors:
-  - David Loeffler, Michael Stoll
+  - David Loeffler
+  - Michael Stoll
   identifiers:
   - Nat.infinite_setOf_prime_and_eq_mod
 

--- a/_thm/Q5533794.md
+++ b/_thm/Q5533794.md
@@ -4,9 +4,9 @@
 wikidata: Q5533794
 msc_classification: '03'
 wikipedia_links:
-- '[[Gentzen's consistency proof]]'
+- "[[Gentzen's consistency proof]]"
 
-coq:
+rocq:
 - status: formalized
   library: X
   url: https://github.com/aarondroidbryce/Gentzen/tree/master

--- a/_thm/Q5566491.md
+++ b/_thm/Q5566491.md
@@ -2,7 +2,17 @@
 # Glaisher's theorem
 
 wikidata: Q5566491
-msc_classification: "11"
+msc_classification: '11'
 wikipedia_links:
-  - "[[Glaisher's theorem]]"
+- '[[Glaisher''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q5566491
+  authors:
+  - Weiyi Wang
+  identifiers:
+  - Nat.Partition.card_restricted_eq_card_countRestricted
+  date: 2025
+
 ---

--- a/_thm/Q574902.md
+++ b/_thm/Q574902.md
@@ -1,10 +1,10 @@
 ---
-# Tarski's indefinability theorem
+# Tarski's undefinability theorem
 
 wikidata: Q574902
 msc_classification: "03"
 wikipedia_links:
-  - "[[Tarski's indefinability theorem]]"
+  - "[[Tarski's undefinability theorem]]"
 lean:
 - status: formalized
   library: X

--- a/_thm/Q574902.md
+++ b/_thm/Q574902.md
@@ -2,9 +2,9 @@
 # Tarski's undefinability theorem
 
 wikidata: Q574902
-msc_classification: "03"
+msc_classification: '03'
 wikipedia_links:
-  - "[[Tarski's undefinability theorem]]"
+- '[[Tarski''s undefinability theorem]]'
 lean:
 - status: formalized
   library: X
@@ -12,4 +12,6 @@ lean:
   authors:
   - Shogo Saito
   - Mashu Noguchi
+  comment: See details for https://formalizedformallogic.github.io/Catalogue/Arithmetic/Tarski___s-Undefinability-Theorem/#tarski-undefinability
+
 ---

--- a/_thm/Q583147.md
+++ b/_thm/Q583147.md
@@ -2,7 +2,16 @@
 # Sard's theorem
 
 wikidata: Q583147
-msc_classification: "53"
+msc_classification: '53'
 wikipedia_links:
-  - "[[Sard's theorem]]"
+- '[[Sard''s theorem]]'
+lean:
+- status: formalized
+  library: X
+  url: https://leanprover-community.github.io/1000.html#Q583147
+  authors:
+  - Yury Kudryashov
+  date: 2025-12-16
+  comment: the manifold version is in progress by Michael Rothgang at https://github.com/fpvandoorn/sard
+
 ---

--- a/_thm/Q588218.md
+++ b/_thm/Q588218.md
@@ -2,7 +2,15 @@
 # Koebe 1/4 theorem
 
 wikidata: Q588218
-msc_classification: "30"
+msc_classification: '30'
 wikipedia_links:
-  - "[[Koebe 1/4 theorem]]"
+- '[[Koebe 1/4 theorem]]'
+lean:
+- status: formalized
+  library: X
+  url: https://leanprover-community.github.io/1000.html#Q588218
+  authors:
+  - Geoffrey Irving
+  date: 2025-09-02
+
 ---

--- a/_thm/Q643826.md
+++ b/_thm/Q643826.md
@@ -2,7 +2,17 @@
 # Slutsky's theorem
 
 wikidata: Q643826
-msc_classification: "60"
+msc_classification: '60'
 wikipedia_links:
-  - "[[Slutsky's theorem]]"
+- '[[Slutsky''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q643826
+  authors:
+  - Rémy Degenne
+  identifiers:
+  - MeasureTheory.TendstoInDistribution.continuous_comp_prodMk_of_tendstoInMeasure_const
+  date: 2025
+
 ---

--- a/_thm/Q6783821.md
+++ b/_thm/Q6783821.md
@@ -10,7 +10,8 @@ lean:
   library: L
   url: https://leanprover-community.github.io/1000.html#Q6783821
   authors:
-  - Jineon Baek, Seewoo Lee
+  - Jineon Baek
+  - Seewoo Lee
   identifiers:
   - Polynomial.abc
   date: 2024

--- a/_thm/Q718875.md
+++ b/_thm/Q718875.md
@@ -10,7 +10,8 @@ lean:
   library: L
   url: https://leanprover-community.github.io/1000.html#Q718875
   authors:
-  - Bhavik Mehta, Yaël Dillies
+  - Bhavik Mehta
+  - Yaël Dillies
   identifiers:
   - Finset.erdos_ko_rado
   date: 2020

--- a/_thm/Q7208500.md
+++ b/_thm/Q7208500.md
@@ -2,7 +2,18 @@
 # Poisson limit theorem
 
 wikidata: Q7208500
-msc_classification: "60"
+msc_classification: '60'
 wikipedia_links:
-  - "[[Poisson limit theorem]]"
+- '[[Poisson limit theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q7208500
+  authors:
+  - Yi Yuan
+  identifiers:
+  - ProbabilityTheory.tendsto_choose_mul_pow_of_tendsto_mul_atTop
+  - ProbabilityTheory.binomial_tendsto_poissonPMFReal_atTop
+  date: 2026
+
 ---

--- a/_thm/Q7249519.md
+++ b/_thm/Q7249519.md
@@ -2,7 +2,17 @@
 # Prokhorov's theorem
 
 wikidata: Q7249519
-msc_classification: "28"
+msc_classification: '28'
 wikipedia_links:
-  - "[[Prokhorov's theorem]]"
+- '[[Prokhorov''s theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q7249519
+  identifiers:
+  - isCompact_setOf_finiteMeasure_mass_le_compl_isCompact_le
+  - isCompact_setOf_finiteMeasure_mass_eq_compl_isCompact_le
+  - isCompact_setOf_probabilityMeasure_mass_eq_compl_isCompact_le
+  - isCompact_closure_of_isTightMeasureSet
+
 ---

--- a/_thm/Q7433182.md
+++ b/_thm/Q7433182.md
@@ -10,7 +10,8 @@ lean:
   library: L
   url: https://leanprover-community.github.io/1000.html#Q7433182
   authors:
-  - Bolton Bailey, Yaël Dillies
+  - Bolton Bailey
+  - Yaël Dillies
   identifiers:
   - MvPolynomial.schwartz_zippel_sup_sum
   date: 2023

--- a/_thm/Q776578.md
+++ b/_thm/Q776578.md
@@ -11,6 +11,7 @@ lean:
   library: L
   url: https://leanprover-community.github.io/1000.html#Q776578
   identifiers:
+  - IsSimpleRing.exists_algEquiv_matrix_divisionRing
   - IsSemisimpleRing.exists_algEquiv_pi_matrix_divisionRing
 
 ---

--- a/_thm/Q7999144.md
+++ b/_thm/Q7999144.md
@@ -10,7 +10,8 @@ lean:
   library: X
   url: https://leanprover-community.github.io/1000.html#Q7999144
   authors:
-  - Alex Kontorovich, Terry Tao,
+  - Alex Kontorovich
+  - Terry Tao
   - the Prime Number Theorem + Project
   date: 2024
 

--- a/_thm/Q853067.md
+++ b/_thm/Q853067.md
@@ -10,7 +10,8 @@ lean:
   library: L
   url: https://leanprover-community.github.io/1000.html#Q853067
   authors:
-  - Mario Carneiro (first), Michael Stoll (second)
+  - Mario Carneiro (first)
+  - Michael Stoll (second)
   identifiers:
   - Pell.eq_pell
   - Pell.exists_of_not_isSquare

--- a/_thm/Q859122.md
+++ b/_thm/Q859122.md
@@ -2,7 +2,17 @@
 # Cauchy–Hadamard theorem
 
 wikidata: Q859122
-msc_classification: "30"
+msc_classification: '30'
 wikipedia_links:
-  - "[[Cauchy–Hadamard theorem]]"
+- '[[Cauchy–Hadamard theorem]]'
+lean:
+- status: formalized
+  library: L
+  url: https://leanprover-community.github.io/1000.html#Q859122
+  authors:
+  - Yury Kudryashov
+  identifiers:
+  - FormalMultilinearSeries.radius_inv_eq_limsup
+  date: 2020
+
 ---

--- a/_thm/Q927051.md
+++ b/_thm/Q927051.md
@@ -2,7 +2,15 @@
 # Riemann mapping theorem
 
 wikidata: Q927051
-msc_classification: "30"
+msc_classification: '30'
 wikipedia_links:
-  - "[[Riemann mapping theorem]]"
+- '[[Riemann mapping theorem]]'
+lean:
+- status: formalized
+  library: X
+  url: https://leanprover-community.github.io/1000.html#Q927051
+  authors:
+  - Vincent Beffara
+  date: 2024
+
 ---

--- a/_thm/Q948664.md
+++ b/_thm/Q948664.md
@@ -1,5 +1,5 @@
 ---
-# Kneser's theorem
+# Kneser's theorem (combinatorics)
 
 wikidata: Q948664
 msc_classification: '05'
@@ -10,7 +10,8 @@ lean:
   library: X
   url: https://leanprover-community.github.io/1000.html#Q948664
   authors:
-  - Mantas Bakšys, Yaël Dillies
+  - Mantas Bakšys
+  - Yaël Dillies
   date: 2022
 
 ---

--- a/sync_mathlib_data.py
+++ b/sync_mathlib_data.py
@@ -363,7 +363,7 @@ def update_data_from_downstream_yaml(input_file: str) -> None:
             new_entry["comment"] = entry["comment"]
         authors = entry.get("authors")
         if authors:
-            authors = authors.split(" and ")
+            authors = authors.replace(", and ", ", ").replace(" and ", ", ").split(", ")
         if status:
             new_entry_typed = FormalisationEntry(
                 status, library, entry.get("url"), authors, new_entry.get('identifiers'), new_entry.get("date"), new_entry.get("comment")


### PR DESCRIPTION
To be merged after #40 and #41.
The additional commits were auto-generated using `sync_mathlib_data.py`.